### PR TITLE
Add config options: queue name, BQ timeout, BQ retries

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,14 @@ en:
           description: |
             The name of the BigQuery dataset we're writing to.
           default: ENV['BIGQUERY_DATASET']
+        bigquery_retries:
+          description: |
+            Passed directly to the retries: option on the BigQuery client
+          default: 3
+        bigquery_timeout:
+          description: |
+            Passed directly to the timeout: option on the BigQuery client
+          default: 120
         enable_analytics:
           description: |
             A proc which returns true or false depending on whether you want to

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,9 @@ en:
         async:
           description: Whether to use ActiveJob or dispatch events immediately.
           default: true
+        queue:
+          description: Which ActiveJob queue to put events on
+          default: ":default"
         bigquery_table_name:
           description: The name of the BigQuery table we’re writing to.
           default: ENV['BIGQUERY_TABLE_NAME']

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -41,6 +41,7 @@ module DfE
       configurables = %i[
         log_only
         async
+        queue
         bigquery_table_name
         bigquery_project_id
         bigquery_dataset
@@ -67,6 +68,7 @@ module DfE
       config.environment           ||= ENV.fetch('RAILS_ENV', 'development')
       config.log_only              ||= false
       config.async                 ||= true
+      config.queue                 ||= :default
     end
 
     def self.enabled?

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -30,8 +30,8 @@ module DfE
         Google::Cloud::Bigquery.new(
           project: config.bigquery_project_id,
           credentials: JSON.parse(config.bigquery_api_json_key),
-          retries: 3,
-          timeout: 120
+          retries: config.bigquery_retries,
+          timeout: config.bigquery_timeout
         ).dataset(config.bigquery_dataset, skip_lookup: true)
                                .table(config.bigquery_table_name, skip_lookup: true)
       end
@@ -45,6 +45,8 @@ module DfE
         bigquery_project_id
         bigquery_dataset
         bigquery_api_json_key
+        bigquery_retries
+        bigquery_timeout
         enable_analytics
         environment
       ]
@@ -60,6 +62,8 @@ module DfE
       config.bigquery_project_id   ||= ENV['BIGQUERY_PROJECT_ID']
       config.bigquery_dataset      ||= ENV['BIGQUERY_DATASET']
       config.bigquery_api_json_key ||= ENV['BIGQUERY_API_JSON_KEY']
+      config.bigquery_retries      ||= 3
+      config.bigquery_timeout      ||= 120
       config.environment           ||= ENV.fetch('RAILS_ENV', 'development')
       config.log_only              ||= false
       config.async                 ||= true

--- a/lib/dfe/analytics/send_events.rb
+++ b/lib/dfe/analytics/send_events.rb
@@ -3,6 +3,8 @@
 module DfE
   module Analytics
     class SendEvents < ActiveJob::Base
+      queue_as { DfE::Analytics.config.queue }
+
       def self.do(events)
         if DfE::Analytics.async?
           perform_later(events)

--- a/lib/dfe/analytics/testing/helpers.rb
+++ b/lib/dfe/analytics/testing/helpers.rb
@@ -36,6 +36,17 @@ module DfE
           stub_request(:post, /bigquery.googleapis.com/)
             .to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
         end
+
+        def with_analytics_config(options)
+          old_config = DfE::Analytics.config.dup
+          DfE::Analytics.configure do |config|
+            options.each { |option, value| config[option] = value }
+          end
+
+          yield
+        ensure
+          DfE::Analytics.instance_variable_set(:@config, old_config)
+        end
       end
     end
   end

--- a/spec/requests/analytics_spec.rb
+++ b/spec/requests/analytics_spec.rb
@@ -76,4 +76,22 @@ RSpec.describe 'Analytics flow', type: :request do
       expect(payload['request_uuid']).to eq(request_uuid)
     end).to have_been_made
   end
+
+  context "when a queue is specified" do
+    it 'uses the specified queue' do
+      with_analytics_config(queue: :my_custom_queue) do
+        expect {
+          get '/example/path'
+        }.to have_enqueued_job.on_queue(:my_custom_queue)
+      end
+    end
+  end
+
+  context "when no queue is specified" do
+    it 'uses the default queue' do
+      expect {
+        get '/example/path'
+      }.to have_enqueued_job.on_queue(:default)
+    end
+  end
 end


### PR DESCRIPTION
Clients can now configure the ActiveJob queue name, plus the BigQuery timeout and retry count options.