### PR TITLE
Standardise event-schema.json

### DIFF
--- a/config/event-schema.json
+++ b/config/event-schema.json
@@ -64,10 +64,6 @@
           "required": ["key", "value"]
         }
       ]
-    },
-    "event_tags": {
-      "type": "array",
-      "items" : [ { "type": "string" } ]
     }
   },
   "additionalProperties": false,

--- a/lib/dfe/analytics/send_events.rb
+++ b/lib/dfe/analytics/send_events.rb
@@ -17,7 +17,7 @@ module DfE
         if DfE::Analytics.log_only?
           Rails.logger.info('DfE::Analytics: ' + events.inspect)
         else
-          DfE::Analytics.events_client.insert(events)
+          DfE::Analytics.events_client.insert(events, ignore_unknown: true)
         end
       end
     end


### PR DESCRIPTION
This is now one-size-fits-all for BAT services. It has some extra Apply-only bits (ie `namespace`) — we can tidy that up if we ever want to.

As schemas in BQ might lack fields we now send, this PR adds `ignore_unknown` to the inserts, which makes the client silently drop fields instead of throwing exceptions. If and when schemas are standardised in BQ (we can in fact generate BQ schemas from the JSON) we can tighten this up again.