### PR TITLE
Make Rails a development_dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,3 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Specify your gem's dependencies in dfe-analytics.gemspec
 gemspec
-
-gem 'rake', '~> 12.0'
-
-# Start debugger with binding.b [https://github.com/ruby/debug]
-gem 'debug', '>= 1.0.0'
-
-gem 'solargraph', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,6 @@ PATH
   specs:
     dfe-analytics (0.1.0)
       google-cloud-bigquery (~> 1.38)
-      i18n
-      rails (>= 6)
       request_store_rails (~> 2)
 
 GEM
@@ -313,7 +311,7 @@ DEPENDENCIES
   debug (>= 1.0.0)
   dfe-analytics!
   json-schema (~> 2.8)
-  rake (~> 12.0)
+  rails (>= 6)
   rspec-rails (~> 5.0)
   rubocop (~> 1.26)
   rubocop-rspec (~> 2)

--- a/dfe-analytics.gemspec
+++ b/dfe-analytics.gemspec
@@ -24,14 +24,15 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency 'google-cloud-bigquery', '~> 1.38'
-  spec.add_dependency 'i18n'
-  spec.add_dependency 'rails', '>= 6'
   spec.add_dependency 'request_store_rails', '~> 2'
 
+  spec.add_development_dependency 'debug', '>= 1.0.0'
   spec.add_development_dependency 'json-schema', '~> 2.8'
+  spec.add_development_dependency 'rails', '>= 6'
   spec.add_development_dependency 'rspec-rails', '~> 5.0'
   spec.add_development_dependency 'rubocop', '~> 1.26'
   spec.add_development_dependency 'rubocop-rspec', '~> 2'
+  spec.add_development_dependency 'solargraph'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'webmock', '~> 3.14'
   spec.metadata['rubygems_mfa_required'] = 'true'


### PR DESCRIPTION
It's not a direct dependency — it's only necessary for executing the code in an environment where Rails isn't present.

**Depends on #9** 