### PR TITLE
Fix rake task when using arguments

### DIFF
--- a/lib/dfe/analytics/load_entities.rb
+++ b/lib/dfe/analytics/load_entities.rb
@@ -8,8 +8,8 @@ module DfE
 
       def initialize(model_name:, start_at_id: nil, sleep_time: nil, batch_size: nil)
         @model_class = Object.const_get(model_name)
-        @sleep_time  = sleep_time.presence || DEFAULT_SLEEP_TIME
-        @batch_size  = batch_size.presence || DEFAULT_BATCH_SIZE
+        @sleep_time  = (sleep_time.presence || DEFAULT_SLEEP_TIME).to_i
+        @batch_size  = (batch_size.presence || DEFAULT_BATCH_SIZE).to_i
         @starting_id = start_at_id || 0 # enable us to complete from a known point of failure :\
       end
 

--- a/spec/dfe/analytics/load_entities_spec.rb
+++ b/spec/dfe/analytics/load_entities_spec.rb
@@ -34,6 +34,15 @@ RSpec.describe DfE::Analytics::LoadEntities do
     end
   end
 
+  it 'converts arguments values' do
+    Candidate.create
+    Candidate.create
+
+    described_class.new(model_name: 'Candidate', batch_size: '1', sleep_time: '0').run
+
+    expect(DfE::Analytics::SendEvents).to have_received(:perform_later).twice
+  end
+
   it 'can work in batches' do
     Candidate.create
     Candidate.create


### PR DESCRIPTION
When using batch size or sleep time from load entities (`bundle exec rails dfe:analytics:import_entity[ModelName,1,1,1]` rake task it raises the exception:

String can't be coerced into Integer

(Refer to
 https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1654509372363969)

By converting the values we guarantee that it will work as expected.