### PR TITLE
make current_user optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ inheriting from `ApplicationRecord`, so these should be a good place to start.
 class ApplicationController < ActionController::Base
   include DfE::Analytics::Requests
 
-  # This method MUST be present in your controller and should return
+  # This method MAY be present in your controller, returning
   # either nil or an object implementing an .id method.
   #
   # def current_user; end

--- a/lib/dfe/analytics/requests.rb
+++ b/lib/dfe/analytics/requests.rb
@@ -16,7 +16,7 @@ module DfE
                                              .with_type('web_request')
                                              .with_request_details(request)
                                              .with_response_details(response)
-                                             .with_user_and_namespace(current_user, try(:current_namespace))
+                                             .with_user_and_namespace(try(:current_user), try(:current_namespace))
                                              .with_request_uuid(RequestLocals.fetch(:dfe_analytics_request_id) { nil })
 
         DfE::Analytics::SendEvents.do([request_event.as_json])

--- a/spec/dfe/analytics/requests_spec.rb
+++ b/spec/dfe/analytics/requests_spec.rb
@@ -5,13 +5,18 @@ RSpec.describe DfE::Analytics::Requests, type: :request do
     controller = Class.new(ApplicationController) do
       include DfE::Analytics::Requests
     end
+    public_api_controller = Class.new(PublicApiController) do
+      include DfE::Analytics::Requests
+    end
 
     stub_const('TestController', controller)
+    stub_const('TestPublicApiController', public_api_controller)
   end
 
   around do |ex|
     Rails.application.routes.draw do
       get '/example/path' => 'test#index'
+      get '/api/public/things' => 'test_public_api#index'
     end
 
     ex.run
@@ -55,5 +60,38 @@ RSpec.describe DfE::Analytics::Requests, type: :request do
       payload = body['rows'].first['json']
       expect(payload.except('occurred_at', 'request_uuid')).to match(a_hash_including(event.deep_stringify_keys))
     end).to have_been_made
+  end
+
+  describe 'an event without user or namespace' do
+    let!(:event) do
+      { environment: 'test',
+        event_type: 'web_request',
+        request_user_agent: nil,
+        request_method: 'GET',
+        request_path: '/api/public/things',
+        request_query: [],
+        request_referer: nil,
+        anonymised_user_agent_and_ip: '12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0',
+        response_content_type: 'application/json; charset=utf-8',
+        response_status: 200,
+        namespace: nil,
+        user_id: nil }
+    end
+
+    it 'does not require a user' do
+      request = stub_analytics_event_submission
+
+      DfE::Analytics::Testing.webmock! do
+        perform_enqueued_jobs do
+          get('/api/public/things')
+        end
+      end
+
+      expect(request.with do |req|
+        body = JSON.parse(req.body)
+        payload = body['rows'].first['json']
+        expect(payload.except('occurred_at', 'request_uuid')).to match(a_hash_including(event.deep_stringify_keys))
+      end).to have_been_made
+    end
   end
 end

--- a/spec/dummy/app/controllers/public_api_controller.rb
+++ b/spec/dummy/app/controllers/public_api_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PublicApiController < ActionController::API
+  def index
+    render json: []
+  end
+end


### PR DESCRIPTION
For controllers that serve public pages/apis, it doesn't make sense to require a 'current_user' method.

This PR allows the `current_user` method to be missing, and adds a test for that. It also adds a test for `current_namespace` to be optional.