### PR TITLE
Don't crash on invalid UTF-8 in headers

### DIFF
--- a/lib/dfe/analytics/event.rb
+++ b/lib/dfe/analytics/event.rb
@@ -33,11 +33,11 @@ module DfE
       def with_request_details(rack_request)
         @event_hash.merge!(
           request_uuid: rack_request.uuid,
-          request_user_agent: rack_request.user_agent,
+          request_user_agent: ensure_utf8(rack_request.user_agent),
           request_method: rack_request.method,
-          request_path: rack_request.path,
+          request_path: ensure_utf8(rack_request.path),
           request_query: hash_to_kv_pairs(Rack::Utils.parse_query(rack_request.query_string)),
-          request_referer: rack_request.referer,
+          request_referer: ensure_utf8(rack_request.referer),
           anonymised_user_agent_and_ip: anonymised_user_agent_and_ip(rack_request)
         )
 
@@ -117,6 +117,10 @@ module DfE
 
       def anonymise(text)
         Digest::SHA2.hexdigest(text)
+      end
+
+      def ensure_utf8(str)
+        str&.scrub
       end
     end
   end

--- a/spec/dfe/analytics/event_spec.rb
+++ b/spec/dfe/analytics/event_spec.rb
@@ -75,6 +75,29 @@ RSpec.describe DfE::Analytics::Event do
     end
   end
 
+  describe 'handling invalid UTF-8' do
+    it 'coerces it to valid UTF-8' do
+      invalid_string = "hello \xbf\xef hello"
+
+      request = fake_request(
+        user_agent: invalid_string
+      )
+
+      event = described_class.new
+      expect(event.with_request_details(request).as_json['request_user_agent']).not_to eq(invalid_string)
+      expect(event.with_request_details(request).as_json['request_user_agent']).to eq('hello �� hello')
+    end
+
+    it 'handles nil' do
+      request = fake_request(
+        user_agent: nil
+      )
+
+      event = described_class.new
+      expect(event.with_request_details(request).as_json['request_user_agent']).to be_nil
+    end
+  end
+
   def fake_request(overrides = {})
     attrs = {
       uuid: '123',

--- a/spec/requests/analytics_spec.rb
+++ b/spec/requests/analytics_spec.rb
@@ -99,4 +99,18 @@ RSpec.describe 'Analytics flow', type: :request do
       end.to have_enqueued_job.on_queue(:default)
     end
   end
+
+  context 'when a non-UTF-8-encoded User Agent is supplied' do
+    it 'coerces it to UTF-8' do
+      stub_analytics_event_submission.with(body: /web_request/)
+
+      string = "\xbf\xef"
+
+      expect do
+        perform_enqueued_jobs do
+          get '/example', headers: { 'User-Agent' => string }
+        end
+      end.not_to raise_error
+    end
+  end
 end

--- a/spec/requests/analytics_spec.rb
+++ b/spec/requests/analytics_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe 'Analytics flow', type: :request do
       include DfE::Analytics::Requests
 
       def index
+        render plain: 'Index page'
+      end
+
+      def create
         Candidate.create(
           email_address: 'a@b.com',
           first_name: 'Mr',
@@ -31,7 +35,8 @@ RSpec.describe 'Analytics flow', type: :request do
 
   around do |ex|
     Rails.application.routes.draw do
-      get '/example/path' => 'test#index'
+      post '/example/create' => 'test#create'
+      get '/example/' => 'test#index'
     end
 
     DfE::Analytics::Testing.webmock! do
@@ -45,8 +50,8 @@ RSpec.describe 'Analytics flow', type: :request do
   it 'works end-to-end' do
     request_event = { environment: 'test',
                       event_type: 'web_request',
-                      request_method: 'GET',
-                      request_path: '/example/path' }
+                      request_method: 'POST',
+                      request_path: '/example/create' }
     request_event_post = stub_analytics_event_submission.with(body: /web_request/)
 
     model_event = { environment: 'test',
@@ -55,7 +60,7 @@ RSpec.describe 'Analytics flow', type: :request do
     model_event_post = stub_analytics_event_submission.with(body: /create_entity/)
 
     perform_enqueued_jobs do
-      get '/example/path'
+      post '/example/create'
     end
 
     request_uuid = nil # we'll compare this across requests
@@ -81,8 +86,8 @@ RSpec.describe 'Analytics flow', type: :request do
     it 'uses the specified queue' do
       with_analytics_config(queue: :my_custom_queue) do
         expect do
-          get '/example/path'
-        end.to have_enqueued_job.twice.on_queue(:my_custom_queue)
+          get '/example'
+        end.to have_enqueued_job.on_queue(:my_custom_queue)
       end
     end
   end
@@ -90,8 +95,8 @@ RSpec.describe 'Analytics flow', type: :request do
   context 'when no queue is specified' do
     it 'uses the default queue' do
       expect do
-        get '/example/path'
-      end.to have_enqueued_job.twice.on_queue(:default)
+        get '/example'
+      end.to have_enqueued_job.on_queue(:default)
     end
   end
 end


### PR DESCRIPTION
Users are able to craft request content which goes to BigQuery by setting request headers. These can include invalid `UTF-8`. This can cause issues at the point of job serialization (Sidekiq can't serialize the args) or at the point of sending to BQ (the Google Cloud library can't build the JSON).

We could preemptively roundtrip events to JSON and back again before putting them on the queue, but the Google library expects hashes so we can't reuse that JSON and it's wasteful. Instead, focus on the things we know can be malformed and fix those: ua and referer. We don't need to worry about about query params as Rails will reject those out of hand - see [ActionDispatch::Request::Utils.check_param_encoding](https://www.rubydoc.info/gems/actionpack/ActionDispatch%2FRequest%2FUtils.check_param_encoding)).

We decided to still send these events, because we send everything, but with � in place of unparseable bytes (which is how String#scrub replaces them).