### PR TITLE
convert data values using to_json

### DIFF
--- a/lib/dfe/analytics/event.rb
+++ b/lib/dfe/analytics/event.rb
@@ -101,6 +101,8 @@ module DfE
 
       def hash_to_kv_pairs(hash)
         hash.map do |(key, value)|
+          value = value.try(:as_json)
+
           if value.in? [true, false]
             value = value.to_s
           elsif value.is_a?(Hash)

--- a/spec/dfe/analytics/event_spec.rb
+++ b/spec/dfe/analytics/event_spec.rb
@@ -62,6 +62,17 @@ RSpec.describe DfE::Analytics::Event do
   end
 
   describe 'data pairs' do
+    let(:has_as_json_class) do
+      Struct.new(:colour, :is_cat) do
+        def as_json
+          {
+            colour: colour,
+            is_cat: is_cat
+          }
+        end
+      end
+    end
+
     it 'converts booleans to strings' do
       event = described_class.new
       output = event.with_data(key: true).as_json
@@ -72,6 +83,12 @@ RSpec.describe DfE::Analytics::Event do
       event = described_class.new
       output = event.with_data(key: { equality_and_diversity: { ethnic_background: 'Irish' } }).as_json
       expect(output['data'].first['value']).to eq ['{"equality_and_diversity":{"ethnic_background":"Irish"}}']
+    end
+
+    it 'handles objects that have JSON-friendly structures' do
+      event = described_class.new
+      output = event.with_data(as_json_object: has_as_json_class.new(:green, true)).as_json
+      expect(output['data'].first['value']).to eq ['{"colour":"green","is_cat":true}']
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 ENV['RAILS_ENV'] = 'test'
 require_relative '../spec/dummy/config/environment'
+require 'debug'
 require 'rspec/rails'
 require 'webmock/rspec'
 require 'json-schema'


### PR DESCRIPTION
When converting event data into the JSON payload to send to BQ, we used
to selectively only convert Hash values to JSON with "to_json". However,
some data values passed through for sending to BigQery may not present as a
Hash, e.g. trainees.progress in Register, causing inseration errors in
BQ.

This change makes us more lenient and will try to convert any value to
JSON if it implements the "to_json" method.