### PR TITLE
Improve testing modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,12 +151,26 @@ BigQuery (respectively) out of the loop.
 
 ### 4. Adding specs
 
-The `dfe-analytics` gem comes with an RSpec matcher that can be used to ensure
-that an integration exists in controllers and models. The RSpec matcher file
-needs to be required into specs, and provides two different styles of matchers
-to use:
+#### Testing modes
 
-``` ruby
+The `dfe-analytics` Gem comes with a testing mode which prevents real analytics from being recorded when running tests.
+
+```ruby
+require 'dfe/analytics/testing'
+
+DfE::Analytics::Testing.fake!
+
+DfE::Analytics::Testing.webmock!
+```
+
+- `fake!` is the default mode, and this effectively stubs the BigQuery client meaning no requests are made.
+- `webmock!` makes the library act as normal, allowing you to write tests against mocked requests.
+
+#### Matchers
+
+The Gem also comes with an RSpec matcher that can be used to ensure that an integration exists in controllers and models. The RSpec matcher file needs to be required into specs, and provides two different styles of matchers to use:
+
+```ruby
 require 'dfe/analytics/rspec/matchers'
 
 # have_sent_analytics_event_types take a block and expects event types to be sent

--- a/lib/dfe/analytics/testing.rb
+++ b/lib/dfe/analytics/testing.rb
@@ -40,7 +40,7 @@ module DfE
     end
 
     class StubClient
-      def insert(_events)
+      def insert(*)
         true
       end
     end

--- a/spec/dfe/analytics/send_events_spec.rb
+++ b/spec/dfe/analytics/send_events_spec.rb
@@ -45,6 +45,17 @@ RSpec.describe DfE::Analytics::SendEvents do
       end
     end
 
+    context 'when using fake testing mode' do
+      it 'does not go out to the network' do
+        request = stub_analytics_event_submission
+
+        DfE::Analytics::Testing.fake! do
+          described_class.new.perform([event.as_json])
+          expect(request).not_to have_been_made
+        end
+      end
+    end
+
     describe 'retry behaviour' do
       before do
         # we don't want to define a permanent exception, just one for this test


### PR DESCRIPTION
This makes two changes to the built-in testing modes to make them easier to use:

- Fixes a bug where `fake!` currently doesn't work as the stubbed `insert` method has the wrong signature.
- Adds a paragraph in the documentation explaining how to use the testing modes.