### PR TITLE
Refactor to straighten out language and improve dfe:analytics:check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,9 @@ Layout/MultilineMethodCallIndentation:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+Metrics/ModuleLength:
+  Enabled: false
+
 # Offense count: 2
 # This cop supports safe auto-correction (--auto-correct).
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DfE::Analytics
 
-**👉 Send every web request and model update to BigQuery**
+**👉 Send every web request and database update to BigQuery**
 
 **✋ Skip or anonymise fields containing PII**
 
@@ -13,9 +13,9 @@ This gem provides an _opinionated integration_ with Google BigQuery.
 Once it is set up, every web request and database update (as permitted by
 configuration) will flow to BigQuery.
 
-It also provides a Rake task for backfilling BigQuery with models created
+It also provides a Rake task for backfilling BigQuery with entities created
 before you started sending events (see **Importing existing data** below), and
-one for keeping your field configuration up to date.
+another for keeping your field configuration up to date.
 
 To set the gem up follow the steps in "Configuration", below.
 
@@ -25,11 +25,13 @@ To set the gem up follow the steps in "Configuration", below.
 
 ## Names and jargon
 
-A Rails model is an analytics **Entity**.
+A Rails model is an analytics **Entity**. All models are entities, but not all
+entities are models — for example, an entity could be an association in a
+many-to-many join table.
 
-A change to a model (including creation and deletion) is an analytics
-**Event**. When a model changes we send the entire new state of the model as
-part of the event.
+A change to a entity (update, creation or deletion) is an analytics **Event**.
+When an entity changes we send the entire new state of the entity as part of
+the event.
 
 A web request is also an analytics **Event**.
 
@@ -48,7 +50,7 @@ sequenceDiagram
     Controller->>Model: Update model
     Model->>Analytics: after_update hook
     Analytics-->>RequestStore: Retrieve request UUID
-    Analytics->>ActiveJob: enqueue Event with serialized model state and request UUID
+    Analytics->>ActiveJob: enqueue Event with serialized entity state and request UUID
     Controller->>Analytics: after_action to send request event
     Analytics->>ActiveJob: enqueue Event with serialized request and request UUID
     Controller->>Client: 200 OK
@@ -306,8 +308,8 @@ bundle exec rails dfe:analytics:check
 ```
 
 This will let you know whether there are any fields in your field configuration
-which are present in the model but missing from the config, or present in the
-config but missing from the model.
+which are present in the database but missing from the config, or present in the
+config but missing from the database.
 
 **It's recommended to run this task regularly - at least as often as you run
 database migrations. Consider enhancing db:migrate to run it automatically.**
@@ -412,10 +414,10 @@ Run
 bundle exec rails dfe:analytics:import_all_entities
 ```
 
-To reimport just one model, run:
+To reimport just one entity, run:
 
 ```bash
-bundle exec rails dfe:analytics:import_entity[ModelName]
+bundle exec rails dfe:analytics:import_entity[entity_name]
 ```
 
 ## Contributing

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -79,15 +79,15 @@ module DfE
     end
 
     def self.allowlist
-      @allowlist ||= Rails.application.config_for(:analytics)
+      Rails.application.config_for(:analytics)
     end
 
     def self.allowlist_pii
-      @allowlist_pii ||= Rails.application.config_for(:analytics_pii)
+      Rails.application.config_for(:analytics_pii)
     end
 
     def self.blocklist
-      @blocklist ||= Rails.application.config_for(:analytics_blocklist)
+      Rails.application.config_for(:analytics_blocklist)
     end
 
     def self.environment

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -103,7 +103,11 @@ module DfE
     end
 
     def self.entities_for_analytics
-      allowlist.keys & entity_model_mapping.keys.map(&:to_sym)
+      allowlist.keys & all_entities_in_application
+    end
+
+    def self.all_entities_in_application
+      entity_model_mapping.keys.map(&:to_sym)
     end
 
     def self.model_for_entity(entity)

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -102,10 +102,6 @@ module DfE
       config.async
     end
 
-    def self.time_zone
-      'London'
-    end
-
     def self.entities_for_analytics
       allowlist.keys & entity_model_mapping.keys.map(&:to_sym)
     end

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -106,16 +106,12 @@ module DfE
       'London'
     end
 
-    def self.models_for_analytics
-      Rails.application.eager_load!
+    def self.entities_for_analytics
+      allowlist.keys & entity_model_mapping.keys.map(&:to_sym)
+    end
 
-      tables_to_models = ActiveRecord::Base.descendants
-        .reject(&:abstract_class?)
-        .to_h { |m| [m.table_name.to_sym, m.name] }
-
-      allowlist.map do |table_name, _|
-        tables_to_models[table_name]
-      end
+    def self.model_for_entity(entity)
+      entity_model_mapping.fetch(entity.to_s)
     end
 
     def self.extract_model_attributes(model, attributes = nil)
@@ -136,5 +132,22 @@ module DfE
     def self.anonymise(value)
       Digest::SHA2.hexdigest(value.to_s)
     end
+
+    def self.entity_model_mapping
+      # ActiveRecord::Base.descendants will collect every model in the
+      # application, including internal models Rails uses to represent
+      # has_and_belongs_to_many relationships without their own models. We map
+      # these back to table_names which are equivalent to dfe-analytics
+      # "entities".
+      @entity_model_mapping ||= begin
+        Rails.application.eager_load!
+
+        ActiveRecord::Base.descendants
+         .reject(&:abstract_class?)
+         .index_by(&:table_name)
+      end
+    end
+
+    private_class_method :entity_model_mapping
   end
 end

--- a/lib/dfe/analytics/event.rb
+++ b/lib/dfe/analytics/event.rb
@@ -114,11 +114,7 @@ module DfE
       end
 
       def anonymised_user_agent_and_ip(rack_request)
-        anonymise(rack_request.user_agent.to_s + rack_request.remote_ip.to_s) if rack_request.remote_ip.present?
-      end
-
-      def anonymise(text)
-        Digest::SHA2.hexdigest(text)
+        DfE::Analytics.anonymise(rack_request.user_agent.to_s + rack_request.remote_ip.to_s) if rack_request.remote_ip.present?
       end
 
       def ensure_utf8(str)

--- a/lib/dfe/analytics/fields.rb
+++ b/lib/dfe/analytics/fields.rb
@@ -23,6 +23,16 @@ module DfE
         diff_model_attributes_against(allowlist)[:surplus]
       end
 
+      def self.conflicting_fields
+        allowlist.keys.reduce({}) do |conflicts, entity|
+          intersection = Array.wrap(blocklist[entity]) & allowlist[entity]
+
+          conflicts[entity] = intersection if intersection.any?
+
+          conflicts
+        end
+      end
+
       def self.diff_model_attributes_against(*lists)
         DfE::Analytics.all_entities_in_application
           .reduce({ missing: {}, surplus: {} }) do |diff, entity|

--- a/lib/dfe/analytics/fields.rb
+++ b/lib/dfe/analytics/fields.rb
@@ -11,47 +11,52 @@ module DfE
         DfE::Analytics.allowlist
       end
 
+      def self.database
+        DfE::Analytics.all_entities_in_application
+          .reduce({}) do |list, entity|
+            attrs = DfE::Analytics.model_for_entity(entity).attribute_names
+            list[entity] = attrs
+
+            list
+          end
+      end
+
       def self.generate_blocklist
-        diff_model_attributes_against(allowlist)[:missing]
+        diff_between(database, allowlist)
       end
 
       def self.unlisted_fields
-        diff_model_attributes_against(allowlist, blocklist)[:missing]
+        diff_between(database, allowlist, blocklist)
       end
 
       def self.surplus_fields
-        diff_model_attributes_against(allowlist)[:surplus]
+        diff_between(allowlist, database)
       end
 
       def self.conflicting_fields
-        allowlist.keys.reduce({}) do |conflicts, entity|
-          intersection = Array.wrap(blocklist[entity]) & allowlist[entity]
-
-          conflicts[entity] = intersection if intersection.any?
-
-          conflicts
-        end
+        diff_between(allowlist, diff_between(allowlist, blocklist))
       end
 
-      def self.diff_model_attributes_against(*lists)
-        DfE::Analytics.all_entities_in_application
-          .reduce({ missing: {}, surplus: {} }) do |diff, entity|
-            attributes_considered = lists.map do |list|
-              # for each list of model attrs, look up the attrs for this model
-              list.fetch(entity, [])
-            end.reduce(:concat)
+      # extract and concatenate the fields associated with an entity in 1 or
+      # more entity->field lists
+      def self.extract_entity_attributes_from_lists(entity, *lists)
+        lists.map do |list|
+          list.fetch(entity, [])
+        end.reduce(:|)
+      end
 
-            model = DfE::Analytics.model_for_entity(entity)
+      # returns keys and values present in leftmost list and not present in any
+      # of the other lists
+      #
+      # diff_between({a: [1, 2]}, {a: [2, 3]}) => {a: [1]}
+      def self.diff_between(primary_list, *lists_to_compare)
+        primary_list.reduce({}) do |diff, (entity, attrs_in_primary_list)|
+          attrs_in_lists_to_compare = extract_entity_attributes_from_lists(entity, *lists_to_compare)
+          differing_attrs = attrs_in_primary_list - attrs_in_lists_to_compare
+          diff[entity] = differing_attrs if differing_attrs.any?
 
-            missing_attributes = model.attribute_names - attributes_considered
-            surplus_attributes = attributes_considered - model.attribute_names
-
-            diff[:missing][entity] = missing_attributes if missing_attributes.any?
-
-            diff[:surplus][entity] = surplus_attributes if surplus_attributes.any?
-
-            diff
-          end
+          diff
+        end
       end
     end
   end

--- a/lib/dfe/analytics/fields.rb
+++ b/lib/dfe/analytics/fields.rb
@@ -24,25 +24,21 @@ module DfE
       end
 
       def self.diff_model_attributes_against(*lists)
-        Rails.application.eager_load!
-        ActiveRecord::Base.descendants
-          .reject { |model| model.name.include? 'ActiveRecord' } # ignore internal AR classes
-          .reduce({ missing: {}, surplus: {} }) do |diff, next_model|
-            table_name = next_model.table_name&.to_sym
+        DfE::Analytics.all_entities_in_application
+          .reduce({ missing: {}, surplus: {} }) do |diff, entity|
+            attributes_considered = lists.map do |list|
+              # for each list of model attrs, look up the attrs for this model
+              list.fetch(entity, [])
+            end.reduce(:concat)
 
-            if table_name.present?
-              attributes_considered = # then combine to get all the attrs we deal with
-                lists.map do |list|
-                  # for each list of model attrs, look up the attrs for this model
-                  list.fetch(table_name, [])
-                end.reduce(:concat)
-              missing_attributes = next_model.attribute_names - attributes_considered
-              surplus_attributes = attributes_considered - next_model.attribute_names
+            model = DfE::Analytics.model_for_entity(entity)
 
-              diff[:missing][table_name] = missing_attributes if missing_attributes.any?
+            missing_attributes = model.attribute_names - attributes_considered
+            surplus_attributes = attributes_considered - model.attribute_names
 
-              diff[:surplus][table_name] = surplus_attributes if surplus_attributes.any?
-            end
+            diff[:missing][entity] = missing_attributes if missing_attributes.any?
+
+            diff[:surplus][entity] = surplus_attributes if surplus_attributes.any?
 
             diff
           end

--- a/lib/dfe/analytics/tasks/fields.rake
+++ b/lib/dfe/analytics/tasks/fields.rake
@@ -4,6 +4,7 @@ namespace :dfe do
     task check: :environment do
       surplus_fields = DfE::Analytics::Fields.surplus_fields
       unlisted_fields = DfE::Analytics::Fields.unlisted_fields
+      conflicting_fields = DfE::Analytics::Fields.conflicting_fields
 
       surplus_fields_failure_message = <<~HEREDOC
         Database field removed! Please remove it from analytics.yml and then run
@@ -26,11 +27,25 @@ namespace :dfe do
         #{unlisted_fields.to_yaml}
       HEREDOC
 
+      conflicting_fields_failure_message = <<~HEREDOC
+        Conflict detected between analytics.yml and analytics_blocklist.yml!
+
+        The following fields exist in both files. To remove from the blocklist, run:
+
+        bundle exec rails dfe:analytics:regenerate_blocklist
+
+        Conflicting fields:
+
+        #{conflicting_fields.to_yaml}
+      HEREDOC
+
       puts unlisted_fields_failure_message if unlisted_fields.any?
 
       puts surplus_fields_failure_message if surplus_fields.any?
 
-      raise if surplus_fields.any? || unlisted_fields.any?
+      puts conflicting_fields_failure_message if conflicting_fields.any?
+
+      raise if surplus_fields.any? || unlisted_fields.any? || conflicting_fields.any?
     end
 
     desc 'Generate a new field blocklist containing all the fields not listed for sending to Bigquery'

--- a/lib/dfe/analytics/tasks/import_entities.rake
+++ b/lib/dfe/analytics/tasks/import_entities.rake
@@ -2,14 +2,14 @@ namespace :dfe do
   namespace :analytics do
     desc 'Send Analytics events for the (allowlisted) state of all records in the database'
     task :import_all_entities, %i[batch_size] => :environment do |_, args|
-      models_for_analytics.each do |model_name|
-        DfE::Analytics::LoadEntities.new(model_name: model_name, **args).run
+      entities_for_analytics.each do |entity_name|
+        DfE::Analytics::LoadEntities.new(entity_name: entity_name, **args).run
       end
     end
 
     desc 'Send Analytics events for the state of all records in a specified model'
-    task :import_entity, %i[model_name batch_size] => :environment do |_, args|
-      abort('You need to specify a model name as an argument to the Rake task, eg dfe:analytics:import_entity[Model]') unless args[:model_name]
+    task :import_entity, %i[entity_name batch_size] => :environment do |_, args|
+      abort('You need to specify a model name as an argument to the Rake task, eg dfe:analytics:import_entity[Model]') unless args[:entity_name]
 
       DfE::Analytics::LoadEntities.new(args).run
     end

--- a/spec/dfe/analytics/fields_spec.rb
+++ b/spec/dfe/analytics/fields_spec.rb
@@ -31,13 +31,25 @@ RSpec.describe DfE::Analytics::Fields do
     end
 
     describe '.conflicting_fields' do
-      let(:existing_allowlist) { { candidates: %w[email_address id], institutions: %w[id] } }
-      let(:existing_blocklist) { { candidates: %w[email_address] } }
+      context 'when fields conflict' do
+        let(:existing_allowlist) { { candidates: %w[email_address id first_name], institutions: %w[id] } }
+        let(:existing_blocklist) { { candidates: %w[email_address first_name] } }
 
-      it 'returns fields in the model that appear in both lists' do
-        conflicts = described_class.conflicting_fields
-        expect(conflicts.keys).to eq(%i[candidates])
-        expect(conflicts[:candidates]).to eq(['email_address'])
+        it 'returns the conflicting fields' do
+          conflicts = described_class.conflicting_fields
+          expect(conflicts.keys).to eq(%i[candidates])
+          expect(conflicts[:candidates]).to eq(%w[email_address first_name])
+        end
+      end
+
+      context 'when there are no conflicts' do
+        let(:existing_allowlist) { { candidates: %w[email_address], institutions: %w[id] } }
+        let(:existing_blocklist) { { candidates: %w[id] } }
+
+        it 'returns nothing' do
+          conflicts = described_class.conflicting_fields
+          expect(conflicts).to be_empty
+        end
       end
     end
 

--- a/spec/dfe/analytics/fields_spec.rb
+++ b/spec/dfe/analytics/fields_spec.rb
@@ -30,6 +30,17 @@ RSpec.describe DfE::Analytics::Fields do
       end
     end
 
+    describe '.conflicting_fields' do
+      let(:existing_allowlist) { { candidates: %w[email_address id], institutions: %w[id] } }
+      let(:existing_blocklist) { { candidates: %w[email_address] } }
+
+      it 'returns fields in the model that appear in both lists' do
+        conflicts = described_class.conflicting_fields
+        expect(conflicts.keys).to eq(%i[candidates])
+        expect(conflicts[:candidates]).to eq(['email_address'])
+      end
+    end
+
     describe '.generate_blocklist' do
       it 'returns all the fields in the model that aren’t in the allowlist' do
         fields = described_class.generate_blocklist[:candidates]

--- a/spec/dfe/analytics/load_entities_spec.rb
+++ b/spec/dfe/analytics/load_entities_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe DfE::Analytics::LoadEntities do
     end
   end
 
-  it 'sends a model’s fields to BQ' do
+  it 'sends a entity’s fields to BQ' do
     Candidate.create(email_address: 'known@address.com')
 
-    described_class.new(model_name: 'Candidate').run
+    described_class.new(entity_name: 'candidates').run
 
     expect(DfE::Analytics::SendEvents).to have_received(:perform_later) do |payload|
       schema = DfE::Analytics::EventSchema.new.as_json
@@ -46,7 +46,7 @@ RSpec.describe DfE::Analytics::LoadEntities do
     Candidate.create
     Candidate.create
 
-    described_class.new(model_name: 'Candidate', batch_size: 2).run
+    described_class.new(entity_name: 'candidates', batch_size: 2).run
 
     expect(DfE::Analytics::SendEvents).to have_received(:perform_later).once
   end

--- a/spec/dfe/analytics_spec.rb
+++ b/spec/dfe/analytics_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DfE::Analytics do
     end
   end
 
-  describe '#models_for_analytics' do
+  describe '#entities_for_analytics' do
     before do
       allow(DfE::Analytics).to receive(:allowlist).and_return({
         candidates: %i[id],
@@ -22,8 +22,8 @@ RSpec.describe DfE::Analytics do
       })
     end
 
-    it 'returns the Rails models in the allowlist' do
-      expect(DfE::Analytics.models_for_analytics).to eq %w[Candidate School]
+    it 'returns the entities in the allowlist' do
+      expect(DfE::Analytics.entities_for_analytics).to eq %i[candidates institutions]
     end
   end
 end


### PR DESCRIPTION
The useful `analytics:check` task detects when we add and remove fields from applications, but it had a shortcoming: it couldn't tell when a field existed in both the allowlist and the blocklist. This wasn't considered first time around because _why would that ever happen_. We now know that it _does_ happen, and it happens when an entity wasn't previously in the allowlist but was in the blocklist (because we ignored it), and now we've added it to the allowlist (because we've decided not to ignore it) and now it's appearing in both.

Not necessarily a problem, but it's unprofessional and confusing and it looks bad so it's no longer allowed 🚫 .

This PR also contains some refactoring to the README and methods which refer to the word `model`. We don't believe in `models` out here; we believe in `entities`. Keep usage of `model` and `table_name` to an absolute minimum so people don't get confused when we're referring to three somewhat equivalent things by three different names.

🤔 **You may notice** that whilst this PR makes a point of saying that we send entity events rather than model events, the README still only talks about mixing the `Entities` behaviour into models. This is because the _next_ PR is going to do away with the manual mixin altogether following very good idea from @misaka that we could do it automatically with information we've got lying around in `DfE::Analytics` — progress continues on that [here](https://github.com/DFE-Digital/dfe-analytics/compare/model-to-entity?expand=1). This will fix a bug where we don't send updates for join tables without an associated model.

This PR best reviewed commit by commit.

