### PR TITLE
detect private current_* methods

### DIFF
--- a/lib/dfe/analytics/requests.rb
+++ b/lib/dfe/analytics/requests.rb
@@ -18,8 +18,8 @@ module DfE
                                              .with_response_details(response)
                                              .with_request_uuid(RequestLocals.fetch(:dfe_analytics_request_id) { nil })
 
-        request_event.with_user(current_user)           if respond_to? :current_user
-        request_event.with_namespace(current_namespace) if respond_to? :current_namespace
+        request_event.with_user(current_user)           if respond_to?(:current_user, true)
+        request_event.with_namespace(current_namespace) if respond_to?(:current_namespace, true)
 
         DfE::Analytics::SendEvents.do([request_event.as_json])
       end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -5,6 +5,8 @@ class ApplicationController < ActionController::Base
     render plain: ''
   end
 
+  private
+
   def current_user
     Struct.new(:id).new(1)
   end


### PR DESCRIPTION
Some services may declare `current_user` (or `current_*` really) as private methods if there is no need to expose that method in the controller. Previously we would miss out on sending the `user_id` with the event if this was the case, this change allows us to detect these as private methods.

For testing purposes, we've made the `current_*` methods private since that ensures we work with both private and public versions of these methods.