### PR TITLE
v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v1.3.0](https://github.com/DFE-Digital/dfe-analytics/tree/v1.3.0) (2022-07-28)
+
+[Full Changelog](https://github.com/DFE-Digital/dfe-analytics/compare/v1.2.1...v1.3.0)
+
+**Merged pull requests:**
+
+- detect private current\_\* methods [\#31](https://github.com/DFE-Digital/dfe-analytics/pull/31) ([misaka](https://github.com/misaka))
+- Refactor to straighten out language and improve dfe:analytics:check [\#30](https://github.com/DFE-Digital/dfe-analytics/pull/30) ([duncanjbrown](https://github.com/duncanjbrown))
+- Raise insertion errors from BigQuery [\#29](https://github.com/DFE-Digital/dfe-analytics/pull/29) ([thomasleese](https://github.com/thomasleese))
+- Expand setup instructions [\#28](https://github.com/DFE-Digital/dfe-analytics/pull/28) ([stevenleggdfe](https://github.com/stevenleggdfe))
+- v1.2.1 [\#27](https://github.com/DFE-Digital/dfe-analytics/pull/27) ([duncanjbrown](https://github.com/duncanjbrown))
+
 ## [v1.2.1](https://github.com/DFE-Digital/dfe-analytics/tree/v1.2.1) (2022-06-28)
 
 [Full Changelog](https://github.com/DFE-Digital/dfe-analytics/compare/v1.2.0...v1.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dfe-analytics (1.2.1)
+    dfe-analytics (1.3.0)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 
@@ -131,9 +131,9 @@ GEM
       rake (>= 10.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    google-apis-bigquery_v2 (0.34.0)
-      google-apis-core (>= 0.5, < 2.a)
-    google-apis-core (0.6.0)
+    google-apis-bigquery_v2 (0.36.0)
+      google-apis-core (>= 0.7, < 2.a)
+    google-apis-core (0.7.0)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -142,7 +142,7 @@ GEM
       retriable (>= 2.0, < 4.a)
       rexml
       webrick
-    google-cloud-bigquery (1.38.1)
+    google-cloud-bigquery (1.39.0)
       concurrent-ruby (~> 1.0)
       google-apis-bigquery_v2 (~> 0.1)
       google-cloud-core (~> 1.6)
@@ -154,7 +154,7 @@ GEM
     google-cloud-env (1.6.0)
       faraday (>= 0.17.3, < 3.0)
     google-cloud-errors (1.2.0)
-    googleauth (1.1.3)
+    googleauth (1.2.0)
       faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -308,9 +308,9 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    signet (0.16.1)
+    signet (0.17.0)
       addressable (~> 2.8)
-      faraday (>= 0.17.5, < 3.0)
+      faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
     solargraph (0.45.0)

--- a/lib/dfe/analytics/version.rb
+++ b/lib/dfe/analytics/version.rb
@@ -2,6 +2,6 @@
 
 module DfE
   module Analytics
-    VERSION = '1.2.1'
+    VERSION = '1.3.0'
   end
 end


### PR DESCRIPTION
Looks like the runtime dependencies from the `gemspec` were updated as part of this. This looks surprising, but it only effects our local dev env, each project will pull in their own versions of these files. The specs are still all 🟢 with this update.