### PR TITLE
[770] handle arrays of JSON-friendly objects

### DIFF
--- a/lib/dfe/analytics/event.rb
+++ b/lib/dfe/analytics/event.rb
@@ -99,17 +99,25 @@ module DfE
 
       private
 
-      def hash_to_kv_pairs(hash)
-        hash.map do |(key, value)|
-          value = value.try(:as_json)
+      def convert_value_to_json(value)
+        value = value.try(:as_json)
 
-          if value.in? [true, false]
-            value = value.to_s
-          elsif value.is_a?(Hash)
-            value = value.to_json
+        if value.in? [true, false]
+          value.to_s
+        elsif value.is_a?(Hash)
+          value.to_json
+        else
+          value
+        end
+      end
+
+      def hash_to_kv_pairs(hash)
+        hash.map do |(key, values)|
+          values_as_json = Array.wrap(values).map do |value|
+            convert_value_to_json(value)
           end
 
-          { 'key' => key, 'value' => Array.wrap(value) }
+          { 'key' => key, 'value' => values_as_json }
         end
       end
 

--- a/spec/dfe/analytics/event_spec.rb
+++ b/spec/dfe/analytics/event_spec.rb
@@ -90,6 +90,14 @@ RSpec.describe DfE::Analytics::Event do
       output = event.with_data(as_json_object: has_as_json_class.new(:green, true)).as_json
       expect(output['data'].first['value']).to eq ['{"colour":"green","is_cat":true}']
     end
+
+    it 'handles arrays of JSON-friendly structures' do
+      event = described_class.new
+      output = event.with_data(
+        as_json_object: [has_as_json_class.new(:green, true)]
+      ).as_json
+      expect(output['data'].first['value']).to eq ['{"colour":"green","is_cat":true}']
+    end
   end
 
   describe 'handling invalid UTF-8' do


### PR DESCRIPTION
We've previously added special handling to event data processing for objects that can be converted to JSON; this change expands that to handle an array of these objects that can be converted to JSON. Words are hard, a ~~picture~~JSON structure is worth a thousand words:

BEFORE BAD:

```json
        {
          "key": "accrediting_provider_enrichments",
          "value": [
            {
              "UcasProviderCode": "N21",
              "Description": "",
              "validation_context": null,
              "errors": {
              }
            }
          ]
        }
```

NOW GOOD:

```json
        {
          "key": "accrediting_provider_enrichments",
          "value": [
            "{\"UcasProviderCode\":\"N21\",\"Description\":\"\",\"validation_context\":null,\"errors\":{}}"
          ]
        }
```

(we now encode each element of the array to JSON).

This has change has also been tested in the test environment.