### PR TITLE
Initialize model callbacks on boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,16 +342,14 @@ end
 
 ##### Models
 
-```ruby
-class ApplicationRecord < ActiveRecord::Base
-  include DfE::Analytics::Entities
-end
-```
+All models in your app will automatically send callbacks if their tables are
+listed in `analytics.yml`. This is a change from versions < v1.4 where it was
+necessary to manually mix in `DfE::Analytics::Entities`. This did not support
+sending events on `has_and_belongs_to_many` tables.
 
-If everything has worked, you should see jobs flowing into your queues on each
-web request and model update. While you’re setting things up consider setting
-the config options `async: false` and `log_only: true` to take ActiveJob and
-BigQuery (respectively) out of the loop.
+While you’re setting things up consider setting the config options `async:
+false` and `log_only: true` to take ActiveJob and BigQuery (respectively) out
+of the loop.
 
 ### Adding specs
 

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -17,6 +17,8 @@ require 'dfe/analytics/railtie'
 
 module DfE
   module Analytics
+    class ConfigurationError < StandardError; end
+
     def self.events_client
       @events_client ||= begin
         require 'google/cloud/bigquery'
@@ -28,7 +30,7 @@ module DfE
           bigquery_api_json_key
         ].select { |val| config.send(val).nil? }
 
-        raise "DfE::Analytics: missing required config values: #{missing_config.join(', ')}" if missing_config.any?
+        raise(ConfigurationError, "DfE::Analytics: missing required config values: #{missing_config.join(', ')}") if missing_config.any?
 
         Google::Cloud::Bigquery.new(
           project: config.bigquery_project_id,

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -76,6 +76,10 @@ module DfE
       config.queue                 ||= :default
     end
 
+    def self.initialize!
+      DfE::Analytics::Fields.check!
+    end
+
     def self.enabled?
       config.enable_analytics.call
     end

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -78,6 +78,15 @@ module DfE
 
     def self.initialize!
       DfE::Analytics::Fields.check!
+
+      entities_for_analytics.each do |entity|
+        model = model_for_entity(entity)
+        if model.include?(DfE::Analytics::Entities) && !@shown_deprecation_warning
+          Rails.logger.info("DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (#{model.name}), but it's included automatically since v1.4. You're running v#{DfE::Analytics::VERSION}. To silence this warning, remove the include from model definitions in app/models.")
+        else
+          model.include(DfE::Analytics::Entities)
+        end
+      end
     end
 
     def self.enabled?
@@ -109,7 +118,7 @@ module DfE
     end
 
     def self.entities_for_analytics
-      allowlist.keys & all_entities_in_application
+      allowlist.keys
     end
 
     def self.all_entities_in_application

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -146,6 +146,17 @@ module DfE
       # these back to table_names which are equivalent to dfe-analytics
       # "entities".
       @entity_model_mapping ||= begin
+        # Gems like devise put helper methods into controllers, and they add
+        # those methods via the routes file.
+        #
+        # Rails.configuration.eager_load = true, which is enabled by default in
+        # production and not in development, will cause routes to be loaded
+        # before controllers; a direct call to Rails.application.eager_load! will
+        # not. To avoid this specific conflict with devise and possibly other
+        # gems/engines, proactively load the routes unless
+        # configuration.eager_load is set.
+        Rails.application.reload_routes! unless Rails.configuration.eager_load
+
         Rails.application.eager_load!
 
         ActiveRecord::Base.descendants

--- a/lib/dfe/analytics/railtie.rb
+++ b/lib/dfe/analytics/railtie.rb
@@ -13,6 +13,10 @@ module DfE
         app.config.middleware.use DfE::Analytics::Middleware::RequestIdentity
       end
 
+      config.after_initialize do
+        DfE::Analytics.initialize!
+      end
+
       rake_tasks do
         path = File.expand_path(__dir__)
         Dir.glob("#{path}/tasks/**/*.rake").each { |f| load f }

--- a/lib/dfe/analytics/railtie.rb
+++ b/lib/dfe/analytics/railtie.rb
@@ -14,7 +14,9 @@ module DfE
       end
 
       config.after_initialize do
-        DfE::Analytics.initialize!
+        # internal gem tests will sometimes suppress this so they can test the
+        # init process
+        DfE::Analytics.initialize! unless ENV['SUPPRESS_DFE_ANALYTICS_INIT']
       end
 
       rake_tasks do

--- a/lib/dfe/analytics/tasks/fields.rake
+++ b/lib/dfe/analytics/tasks/fields.rake
@@ -2,50 +2,7 @@ namespace :dfe do
   namespace :analytics do
     desc 'Generate a new field blocklist containing all the fields not listed for sending to Bigquery'
     task check: :environment do
-      surplus_fields = DfE::Analytics::Fields.surplus_fields
-      unlisted_fields = DfE::Analytics::Fields.unlisted_fields
-      conflicting_fields = DfE::Analytics::Fields.conflicting_fields
-
-      surplus_fields_failure_message = <<~HEREDOC
-        Database field removed! Please remove it from analytics.yml and then run
-
-        bundle exec rails dfe:analytics:regenerate_blocklist
-
-        Removed fields:
-
-        #{surplus_fields.to_yaml}
-      HEREDOC
-
-      unlisted_fields_failure_message = <<~HEREDOC
-        New database field detected! You need to decide whether or not to send it
-        to BigQuery. To send, add it to config/analytics.yml. To ignore, run:
-
-        bundle exec rails dfe:analytics:regenerate_blocklist
-
-        New fields:
-
-        #{unlisted_fields.to_yaml}
-      HEREDOC
-
-      conflicting_fields_failure_message = <<~HEREDOC
-        Conflict detected between analytics.yml and analytics_blocklist.yml!
-
-        The following fields exist in both files. To remove from the blocklist, run:
-
-        bundle exec rails dfe:analytics:regenerate_blocklist
-
-        Conflicting fields:
-
-        #{conflicting_fields.to_yaml}
-      HEREDOC
-
-      puts unlisted_fields_failure_message if unlisted_fields.any?
-
-      puts surplus_fields_failure_message if surplus_fields.any?
-
-      puts conflicting_fields_failure_message if conflicting_fields.any?
-
-      raise if surplus_fields.any? || unlisted_fields.any? || conflicting_fields.any?
+      DfE::Analytics::Fields.check!
     end
 
     desc 'Generate a new field blocklist containing all the fields not listed for sending to Bigquery'

--- a/spec/dfe/analytics/entities_spec.rb
+++ b/spec/dfe/analytics/entities_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe DfE::Analytics::Entities do
       t.string :last_name
       t.string :first_name
     end
-
-    model { include DfE::Analytics::Entities }
   end
 
   before do
@@ -27,9 +25,7 @@ RSpec.describe DfE::Analytics::Entities do
     })
 
     # autogenerate a compliant blocklist
-    blocklist = DfE::Analytics::Fields.database
-    blocklist[Candidate.table_name.to_sym] = blocklist[Candidate.table_name.to_sym] - interesting_fields
-    allow(DfE::Analytics).to receive(:blocklist).and_return(blocklist)
+    allow(DfE::Analytics).to receive(:blocklist).and_return(DfE::Analytics::Fields.generate_blocklist)
 
     DfE::Analytics.initialize!
   end

--- a/spec/dfe/analytics/entities_spec.rb
+++ b/spec/dfe/analytics/entities_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe DfE::Analytics::Entities do
 
   describe 'create_entity events' do
     context 'when fields are specified in the analytics file' do
-      let(:interesting_fields) { ["id"] }
+      let(:interesting_fields) { ['id'] }
 
       it 'includes attributes specified in the settings file' do
         Candidate.create(id: 123)
@@ -84,8 +84,8 @@ RSpec.describe DfE::Analytics::Entities do
       end
 
       context 'and the specified fields are listed as PII' do
-        let(:interesting_fields) { ["email_address"] }
-        let(:pii_fields) { ["email_address"] }
+        let(:interesting_fields) { ['email_address'] }
+        let(:pii_fields) { ['email_address'] }
 
         it 'hashes those fields' do
           Candidate.create(email_address: 'adrienne@example.com')
@@ -101,8 +101,8 @@ RSpec.describe DfE::Analytics::Entities do
       end
 
       context 'and other fields are listed as PII' do
-        let(:interesting_fields) { ["id"] }
-        let(:pii_fields) { ["email_address"] }
+        let(:interesting_fields) { ['id'] }
+        let(:pii_fields) { ['email_address'] }
 
         it 'does not include the fields only listed as PII' do
           Candidate.create(id: 123, email_address: 'adrienne@example.com')
@@ -187,7 +187,7 @@ RSpec.describe DfE::Analytics::Entities do
   end
 
   describe 'delete_entity events' do
-    let(:interesting_fields) { ["email_address"] }
+    let(:interesting_fields) { ['email_address'] }
 
     it 'sends events when objects are deleted' do
       entity = Candidate.create(email_address: 'boo@example.com')

--- a/spec/dfe/analytics/fields_spec.rb
+++ b/spec/dfe/analytics/fields_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe DfE::Analytics::Fields do
         expect(fields).not_to include('email_address')
         expect(fields).not_to include('id')
       end
+
+      describe '.check!' do
+        it 'raises an error' do
+          expect { DfE::Analytics::Fields.check! }.to raise_error(DfE::Analytics::ConfigurationError, /New database field detected/)
+        end
+      end
     end
 
     describe '.conflicting_fields' do
@@ -46,6 +52,12 @@ RSpec.describe DfE::Analytics::Fields do
         it 'returns the conflicting fields' do
           conflicts = described_class.conflicting_fields
           expect(conflicts[Candidate.table_name.to_sym]).to eq(%w[email_address first_name])
+        end
+
+        describe '.check!' do
+          it 'raises an error' do
+            expect { DfE::Analytics::Fields.check! }.to raise_error(DfE::Analytics::ConfigurationError, /Conflict detected/)
+          end
         end
       end
 
@@ -84,6 +96,12 @@ RSpec.describe DfE::Analytics::Fields do
         it 'returns the field that has been removed' do
           fields = described_class.surplus_fields[Candidate.table_name.to_sym]
           expect(fields).to eq ['some_removed_field']
+        end
+      end
+
+      describe '.check!' do
+        it 'raises an error' do
+          expect { DfE::Analytics::Fields.check! }.to raise_error(DfE::Analytics::ConfigurationError, /Database field removed/)
         end
       end
     end

--- a/spec/dfe/analytics_spec.rb
+++ b/spec/dfe/analytics_spec.rb
@@ -18,6 +18,32 @@ RSpec.describe DfE::Analytics do
     end
   end
 
+  describe 'initalization' do
+    # field validity is computed from allowlist, blocklist and database. See
+    # Analytics::Fields for more details
+    context 'when the field lists are valid' do
+      before do
+        allow(DfE::Analytics).to receive(:allowlist).and_return(
+          Candidate.table_name.to_sym => ['id']
+        )
+      end
+
+      it 'raises no error' do
+        expect { DfE::Analytics.initialize! }.not_to raise_error
+      end
+    end
+
+    context 'when a field list is invalid' do
+      before do
+        allow(DfE::Analytics).to receive(:allowlist).and_return({ invalid: [:fields] })
+      end
+
+      it 'raises an error' do
+        expect { DfE::Analytics.initialize! }.to raise_error(DfE::Analytics::ConfigurationError)
+      end
+    end
+  end
+
   it 'raises a configuration error on missing config values' do
     with_analytics_config(bigquery_project_id: nil) do
       DfE::Analytics::Testing.webmock! do

--- a/spec/dfe/analytics_spec.rb
+++ b/spec/dfe/analytics_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe DfE::Analytics do
     end
   end
 
+  it 'raises a configuration error on missing config values' do
+    with_analytics_config(bigquery_project_id: nil) do
+      DfE::Analytics::Testing.webmock! do
+        expect { DfE::Analytics.events_client }.to raise_error(DfE::Analytics::ConfigurationError)
+      end
+    end
+  end
+
   describe '#entities_for_analytics' do
     before do
       allow(DfE::Analytics).to receive(:allowlist).and_return({

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,7 @@ RSpec.configure do |config|
 
   config.before do
     DfE::Analytics.instance_variable_set(:@entity_model_mapping, nil)
+    DfE::Analytics.instance_variable_set(:@events_client, nil)
   end
 
   config.expect_with :rspec do |c|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 ENV['RAILS_ENV'] = 'test'
+ENV['SUPPRESS_DFE_ANALYTICS_INIT'] = 'true'
+
 require_relative '../spec/dummy/config/environment'
 require 'debug'
 require 'rspec/rails'
@@ -32,6 +34,15 @@ RSpec.configure do |config|
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
+
+  config.define_derived_metadata do |metadata|
+    metadata[:skip_analytics_init] = true unless metadata[:skip_analytics_init] == false
+  end
+
+  config.around skip_analytics_init: false do |example|
+    DfE::Analytics.initialize!
+    example.run
+  end
 
   config.expect_with :rspec do |c|
     c.syntax = :expect


### PR DESCRIPTION
See commits.

Manually mixing the behaviour in to ActiveRecord classes does not achieve what we want to achieve: it missed out HABTM relations. So hook up everything automatically — `analytics.yml` will determine what gets sent. As part of this piece of work we now refuse to boot if that file isn't correct, which should surface configuration issues as early as possible.

Depends on #36.