### PR TITLE
Fix rake tasks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
-    async (2.0.3)
+    async (2.0.0)
       console (~> 1.10)
       io-event (~> 1.0.0)
       timers (~> 4.1)

--- a/lib/dfe/analytics/tasks/import_entities.rake
+++ b/lib/dfe/analytics/tasks/import_entities.rake
@@ -2,7 +2,7 @@ namespace :dfe do
   namespace :analytics do
     desc 'Send Analytics events for the (allowlisted) state of all records in the database'
     task :import_all_entities, %i[batch_size] => :environment do |_, args|
-      entities_for_analytics.each do |entity_name|
+      DfE::Analytics.entities_for_analytics.each do |entity_name|
         DfE::Analytics::LoadEntities.new(entity_name: entity_name, **args).run
       end
     end
@@ -11,7 +11,7 @@ namespace :dfe do
     task :import_entity, %i[entity_name batch_size] => :environment do |_, args|
       abort('You need to specify a model name as an argument to the Rake task, eg dfe:analytics:import_entity[Model]') unless args[:entity_name]
 
-      DfE::Analytics::LoadEntities.new(args).run
+      DfE::Analytics::LoadEntities.new(**args).run
     end
   end
 end


### PR DESCRIPTION
Tried to run one of the rake tasks in Publish and it was complaining about structure of args. This PR introduces a couple of fixes:

- Fixes rake task `:import_all_entities`, eg:

```ruby
NameError: undefined local variable or method `entities_for_analytics' for main:Object

      entities_for_analytics.each do |entity_name|

```

- Fixes rake task `:import_entity` to correctly destructure args otherwise we get:

```ruby
ArgumentError: wrong number of arguments (given 1, expected 0; required keyword: entity_name)
```

- Pins async gem to a version that hasn't been yanked

Also pinned the async gem to a version that hasn't been yanked, let me know if this is ok.