### PR TITLE
allow user id field to be configurable

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,6 +47,9 @@ en:
             The environment we’re running in. This value will be attached
             to all events we send to BigQuery.
           default: ENV.fetch('RAILS_ENV', 'development')
-
-
-
+        user_identifier:
+          description: |
+            A proc which will be called with the user object, and which should
+            return the identifier for the user. This is useful for systems with
+            users that don't use the id field.
+          default: proc { |user| user&.id }

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -55,6 +55,7 @@ module DfE
         bigquery_timeout
         enable_analytics
         environment
+        user_identifier
       ]
 
       @config ||= Struct.new(*configurables).new
@@ -74,6 +75,7 @@ module DfE
       config.log_only              ||= false
       config.async                 ||= true
       config.queue                 ||= :default
+      config.user_identifier       ||= proc { |user| user&.id }
     end
 
     def self.initialize!
@@ -175,5 +177,9 @@ module DfE
     end
 
     private_class_method :entity_model_mapping
+
+    def self.user_identifier(user)
+      config.user_identifier.call(user)
+    end
   end
 end

--- a/lib/dfe/analytics/event.rb
+++ b/lib/dfe/analytics/event.rb
@@ -55,7 +55,7 @@ module DfE
 
       def with_user(user)
         @event_hash.merge!(
-          user_id: user&.id
+          user_id: DfE::Analytics.user_identifier(user)
         )
 
         self

--- a/spec/dfe/analytics/event_spec.rb
+++ b/spec/dfe/analytics/event_spec.rb
@@ -123,6 +123,33 @@ RSpec.describe DfE::Analytics::Event do
     end
   end
 
+  describe 'with_user' do
+    let(:regular_user_class) { Struct.new(:id) }
+
+    it 'uses user.id by default' do
+      event = described_class.new
+      id = rand(1000)
+      output = event.with_user(regular_user_class.new(id)).as_json
+      expect(output['user_id']).to eq id
+    end
+
+    context 'users that use uuid as an identifier' do
+      let(:custom_user_class) { Struct.new(:uuid) }
+
+      before do
+        allow(DfE::Analytics).to receive(:user_identifier, &:uuid)
+      end
+
+      it 'uses the user_identifier proc to extract user id' do
+        event = described_class.new
+        uuid = SecureRandom.uuid
+        output = event.with_user(custom_user_class.new(uuid)).as_json
+
+        expect(output['user_id']).to eq uuid
+      end
+    end
+  end
+
   def fake_request(overrides = {})
     attrs = {
       uuid: '123',

--- a/spec/dfe/analytics_spec.rb
+++ b/spec/dfe/analytics_spec.rb
@@ -127,4 +127,27 @@ RSpec.describe DfE::Analytics do
       expect(DfE::Analytics.entities_for_analytics).to eq [Candidate.table_name.to_sym]
     end
   end
+
+  describe '#user_identifier' do
+    let(:user_class) { Struct.new(:id) }
+    let(:id) { rand(1000) }
+    let(:user) { user_class.new(id) }
+
+    it 'calls the user_identifier configation' do
+      expect(described_class.user_identifier(user)).to eq id
+    end
+
+    context 'with a customised user_identifier proc' do
+      let(:user_class) { Struct.new(:identifier) }
+
+      before do
+        allow(described_class.config).to receive(:user_identifier)
+                                           .and_return(->(user) { user.identifier })
+      end
+
+      it 'delegates to the provided proc' do
+        expect(described_class.user_identifier(user)).to eq id
+      end
+    end
+  end
 end


### PR DESCRIPTION
Some systems may not be able to, or prefer not to, use the id attribute
on user to identify the user. Allow these systems to call a different
method on the user to return an identifier.

This change should not break existing systems as defaults to using `user.id` as the previous systems did.