### PR TITLE
Pass model names as strings when loading batches

### DIFF
--- a/lib/dfe/analytics/load_entities.rb
+++ b/lib/dfe/analytics/load_entities.rb
@@ -21,7 +21,7 @@ module DfE
 
           ids = relation.pluck(:id)
 
-          DfE::Analytics::LoadEntityBatch.perform_later(model, ids, batch_number)
+          DfE::Analytics::LoadEntityBatch.perform_later(model.to_s, ids, batch_number)
         end
 
         Rails.logger.info "Enqueued #{batch_number} batches of #{@batch_size} #{@entity_name} for importing to BigQuery"

--- a/lib/dfe/analytics/load_entity_batch.rb
+++ b/lib/dfe/analytics/load_entity_batch.rb
@@ -2,6 +2,9 @@ module DfE
   module Analytics
     class LoadEntityBatch < AnalyticsJob
       def perform(model_class, ids, batch_number)
+        # Support string args for Rails < 6.1
+        model_class = model_class.constantize if model_class.respond_to?(:constantize)
+
         events = model_class.where(id: ids).map do |record|
           DfE::Analytics::Event.new
             .with_type('import_entity')

--- a/spec/dfe/analytics/load_entity_batch_spec.rb
+++ b/spec/dfe/analytics/load_entity_batch_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe DfE::Analytics::LoadEntityBatch do
+  include ActiveJob::TestHelper
+
+  with_model :Candidate do
+    table do |t|
+      t.string :email_address
+    end
+  end
+
+  before do
+    allow(DfE::Analytics::SendEvents).to receive(:perform_later)
+  end
+
+  around do |ex|
+    perform_enqueued_jobs do
+      ex.run
+    end
+  end
+
+  it 'accepts its first arg as a String to support Rails < 6.1' do
+    # Rails 6.1rc1 added support for deserializing Class and Module params
+    c = Candidate.create(email_address: 'foo@example.com')
+
+    described_class.perform_later('Candidate', [c.id], 1)
+
+    expect(DfE::Analytics::SendEvents).to have_received(:perform_later).once
+  end
+
+  it 'accepts its first arg as a Class' do
+    # backwards compatability with existing enqueued jobs
+    c = Candidate.create(email_address: 'foo@example.com')
+
+    described_class.perform_later(Candidate, [c.id], 1)
+
+    expect(DfE::Analytics::SendEvents).to have_received(:perform_later).once
+  end
+end


### PR DESCRIPTION
ActiveJob < 6.1 cannot handle classes in params

"Allow Class and Module instances to be serialized." appeared in
Rails changelog at https://github.com/rails/rails/releases/tag/v6.1.0.rc1

Fixes https://trello.com/c/nLQjJ9YM/816-blocks-claim-onboarding-class-serialisation-error-during-dfe-analytics-backfill