### PR TITLE
Change ActiveJob log level

### DIFF
--- a/lib/dfe/analytics/railtie.rb
+++ b/lib/dfe/analytics/railtie.rb
@@ -13,6 +13,19 @@ module DfE
         app.config.middleware.use DfE::Analytics::Middleware::RequestIdentity
       end
 
+      initializer 'dfe.analytics.logger' do
+        ActiveSupport.on_load(:active_job) do
+          analytics_job = DfE::Analytics::AnalyticsJob
+          # Rails < 6.1 doesn't support log_arguments = false so we only log warn
+          # to prevent wild log inflation
+          if analytics_job.respond_to?(:log_arguments=)
+            analytics_job.log_arguments = false
+          else
+            analytics_job.logger = ::Rails.logger.dup.tap { |l| l.level = Logger::WARN }
+          end
+        end
+      end
+
       config.after_initialize do
         # internal gem tests will sometimes suppress this so they can test the
         # init process

--- a/lib/dfe/analytics/send_events.rb
+++ b/lib/dfe/analytics/send_events.rb
@@ -13,6 +13,7 @@ module DfE
 
       def perform(events)
         if DfE::Analytics.log_only?
+          # Use the Rails logger here as the job's logger is set to :warn by default
           Rails.logger.info("DfE::Analytics: #{events.inspect}")
         else
           response = DfE::Analytics.events_client.insert(events, ignore_unknown: true)

--- a/lib/generators/dfe/analytics/install_generator.rb
+++ b/lib/generators/dfe/analytics/install_generator.rb
@@ -26,10 +26,6 @@ module DfE
           DESC
         end
       end
-
-      # def self.banner(command, namespace = nil, subcommand = false)
-      #   "#{basename} #{subcommand_prefix} #{command.usage}"
-      # end
     end
   end
 end


### PR DESCRIPTION
It was necessary to defer setting the logger to after ActiveJob had loaded, because ActiveJob sets a logger in its own Railtie.

https://github.com/rails/rails/blob/a5018cf149d47e1aed1e74dd35e4d519b507c364/activejob/lib/active_job/railtie.rb#L13-L15