### PR TITLE
ignore version release PRs in changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ bundle exec rails dfe:analytics:import_entity[entity_name]
 3. (Optional) Verify committed `CHANGELOG.md` changes and alter if necessary: `git show`
 4. Push the branch: `git push origin v${NEW_VERSION}-release`, e.g. `git push origin v1.3.0-release`
 5. Push the tags: `git push --tags`
-6. Cut a PR on GitHub and merge once approved. 
+6. Cut a PR on GitHub with the label `version-release`, and merge once approved
 
 ## License
 

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ task :prepare_release, %i[version] do |_, args|
 
   v_version = "v#{version}"
 
-  sh 'github_changelog_generator', '--no-verbose', '--future-release', v_version
+  sh 'github_changelog_generator', '--no-verbose', '--future-release', v_version, '--exclude-labels', 'version-release'
 
   sh 'git', 'commit', '-a', '-m', v_version
 


### PR DESCRIPTION
This change allows us omit PRs labeled with `version-release` from the automatically generated `CHANGELOG.md` file. This just makes the changelog slightly tidier and is purely cosmetic.