### PR TITLE
Ignore models with non-id primary keys

### DIFF
--- a/lib/dfe/analytics/load_entities.rb
+++ b/lib/dfe/analytics/load_entities.rb
@@ -18,6 +18,11 @@ module DfE
           return
         end
 
+        unless model.primary_key.to_sym == :id
+          Rails.logger.info("Not processing #{@entity_name} as we do not support non-id primary keys")
+          return
+        end
+
         Rails.logger.info("Processing data for #{@entity_name} with row count #{model.count}")
 
         batch_count = 0


### PR DESCRIPTION
We can probably handle these, but it would involve fixing find_in_batches to work with non-id PKs, which is out of scope for now