### PR TITLE
🍀 Four kinds of init error

### DIFF
--- a/spec/dfe/analytics_spec.rb
+++ b/spec/dfe/analytics_spec.rb
@@ -22,6 +22,15 @@ RSpec.describe DfE::Analytics do
     end
   end
 
+  describe 'when migrations are pending' do
+    it 'recovers and logs' do
+      allow(DfE::Analytics::Fields).to receive(:check!).and_raise(ActiveRecord::PendingMigrationError)
+
+      allow(Rails.logger).to receive(:info).with(/Database requires migration/)
+      expect { DfE::Analytics.initialize! }.not_to raise_error
+    end
+  end
+
   describe 'field checks on initialization' do
     # field validity is computed from allowlist, blocklist and database. See
     # Analytics::Fields for more details


### PR DESCRIPTION
4️⃣   error conditions we discovered during recent rollout in Publish and Apply CI pipelines.

- ActiveRecord::SchemaMigrations table is being considered for dfe-analytics (ignore it)
- discovering migrations pending on dfe-analytics init
- discovering missing database connection when database not present, also on init
- loading models (in init) before connecting to DB

The final example is important because some contexts which lack db connections (eg asset precompilation) also don't provide all necessary eg ENV vars which would be required were we loading the whole app (which this init process does).

So discover early if we have no database (call `ActiveRecord::Base.connection`). & if anything happens during Fields.check! catch that too. Log lines will tell us if we're bailing for want of a DB or for want of a migration. (There's no point in running check! if migration yet to run).