### PR TITLE
Recover when the database hasn’t been set up yet

### DIFF
--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -79,7 +79,8 @@ module DfE
     end
 
     def self.initialize!
-      ActiveRecord::Base.connection # cause an exception early if we can't connect
+      raise ActiveRecord::PendingMigrationError if ActiveRecord::Base.connection.migration_context.needs_migration?
+
       DfE::Analytics::Fields.check!
 
       entities_for_analytics.each do |entity|

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -79,6 +79,12 @@ module DfE
     end
 
     def self.initialize!
+      unless defined?(ActiveRecord)
+        # bail if we don't have AR at all
+        Rails.logger.info('ActiveRecord not loaded; DfE Analytics not initialized')
+        return
+      end
+
       raise ActiveRecord::PendingMigrationError if ActiveRecord::Base.connection.migration_context.needs_migration?
 
       DfE::Analytics::Fields.check!

--- a/spec/dfe/analytics_spec.rb
+++ b/spec/dfe/analytics_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DfE::Analytics do
   describe 'when no database connection is available' do
     it 'recovers and logs' do
       allow(ActiveRecord::Base).to receive(:connection).and_raise(ActiveRecord::ConnectionNotEstablished)
-      allow(Rails.logger).to receive(:info).with(/No database connection/)
+      expect(Rails.logger).to receive(:info).with(/No database connection/)
       expect { DfE::Analytics.initialize! }.not_to raise_error
     end
   end
@@ -26,7 +26,16 @@ RSpec.describe DfE::Analytics do
     it 'recovers and logs' do
       allow(DfE::Analytics::Fields).to receive(:check!).and_raise(ActiveRecord::PendingMigrationError)
 
-      allow(Rails.logger).to receive(:info).with(/Database requires migration/)
+      expect(Rails.logger).to receive(:info).with(/Database requires migration/)
+      expect { DfE::Analytics.initialize! }.not_to raise_error
+    end
+  end
+
+  describe 'when ActiveRecord is not loaded' do
+    it 'recovers and logs' do
+      hide_const('ActiveRecord')
+
+      expect(Rails.logger).to receive(:info).with(/ActiveRecord not loaded/)
       expect { DfE::Analytics.initialize! }.not_to raise_error
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,11 @@ RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
+  config.around do |example|
+    ActiveRecord::Base.connection.migration_context.migrate
+    example.run
+  end
+
   config.define_derived_metadata do |metadata|
     metadata[:skip_analytics_init] = true unless metadata[:skip_analytics_init] == false
   end


### PR DESCRIPTION
And another build-related edge case 😅 

Manually throw a MigrationPending exception, or else, in cases where app code begins executing before migration has run (eg worker instances that override default Docker entrypoints) and there is no DB schema yet (eg review apps), we get an error saying that the whole schema needs to be put into the blocklist