### PR TITLE
Custom events

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ event = DfE::Analytics::Event.new
 Once all the events have been constructed, simply send them to your analytics:
 
 ```ruby
-DfE::Analytics::SendEvents.do(event, event2, event3, ...)
+DfE::Analytics::SendEvents.do([event, event2, event3])
 ```
 
 #### Controllers

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ event = DfE::Analytics::Event.new
 Once all the events have been constructed, simply send them to your analytics:
 
 ```ruby
-DfE::Analytics::SendEvent.do(event, event2, event3, ...)
+DfE::Analytics::SendEvents.do(event, event2, event3, ...)
 ```
 
 #### Controllers

--- a/lib/dfe/analytics/send_events.rb
+++ b/lib/dfe/analytics/send_events.rb
@@ -4,6 +4,8 @@ module DfE
   module Analytics
     class SendEvents < AnalyticsJob
       def self.do(events)
+        events = events.map { |event| event.is_a?(Event) ? event.as_json : event }
+
         if DfE::Analytics.async?
           perform_later(events)
         else


### PR DESCRIPTION
DfE::Analytics::SendEvents expects an array of hashes. This change allows passing constructed DfE::Analytics::Event object as well, without need to convert them into hashes first.