### PR TITLE
Log Matched Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,9 +348,9 @@ Event filters allow targeted event logging for diagnostic and debug purposes. Th
 When defining event filters, note the following:
 - All values are converted to regular expressions for matching
 - Any filter fields can be defined as long as the field exists in the target event
-- A filter must be a hash and nesteds field are allowed.
-- If a corresponding hash field in the target event is not found, then the remaining value in the target is converted into a string and compared with the value from the filter. The remaining nested fileds in the filter are then ignored. This may result in a wider match than expected
-- If there are mutiple filters then at least one must match the event
+- A filter must be a hash and nested fields are allowed
+- If a corresponding hash field in the target event is not found, then the remaining value in the target is converted into a string and compared with the value from the filter. The remaining nested fields in the filter are then ignored. This may result in a wider match than expected
+- If there are multiple filters then at least one must match the event
 - All filter fields must match the event fields for a filter to match
 
 In the above example, all CRUD entity events to the `course_options` table and `id` matching value `1234` will be logged, or any update events to the `courses` table will also be logged.

--- a/README.md
+++ b/README.md
@@ -334,12 +334,13 @@ If you wish to log events for debug purposes, create a file `config/analytics_ev
 shared:
   event_filters:
     -
-      type: (create|update|delete)_entity
+      event_type: (create|update|delete)_entity
       entity_table_name: course_options
-      key: id
-      value: 12345
+      data:
+        key: id
+        value: 12345
     -
-      type: update_entity
+      event_type: import_entity
       entity_table_name: courses
 ```
 
@@ -353,7 +354,7 @@ When defining event filters, note the following:
 - If there are multiple filters then at least one must match the event
 - All filter fields must match the event fields for a filter to match
 
-In the above example, all CRUD entity events to the `course_options` table and `id` matching value `1234` will be logged, or any update events to the `courses` table will also be logged.
+In the above example, all create, delete or update entity events to the `course_options` table and `id` matching value `1234` will be logged, or any import entity events to the `courses` table will also be logged.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -325,6 +325,36 @@ To reimport just one entity, run:
 bundle exec rails dfe:analytics:import_entity[entity_name]
 ```
 
+
+## Event debugging
+
+If you wish to log events for debug purposes, create a file `config/analytics_event_debug.yml` containing an array of your event filters  under a `shared` key like:
+
+```yaml
+shared:
+  event_filters:
+    -
+      type: (create|update|delete)_entity
+      entity_table_name: course_options
+      key: id
+      value: 12345
+    -
+      type: update_entity
+      entity_table_name: courses
+```
+
+Event filters allow targeted event logging for diagnostic and debug purposes. The logging level is `info`.
+
+When defining event filters, note the following:
+- All values are converted to regular expressions for matching
+- Any filter fields can be defined as long as the field exists in the target event
+- A filter must be a hash and nesteds field are allowed.
+- If a corresponding hash field in the target event is not found, then the remaining value in the target is converted into a string and compared with the value from the filter. The remaining nested fileds in the filter are then ignored. This may result in a wider match than expected
+- If there are mutiple filters then at least one must match the event
+- All filter fields must match the event fields for a filter to match
+
+In the above example, all CRUD entity events to the `course_options` table and `id` matching value `1234` will be logged, or any update events to the `courses` table will also be logged.
+
 ## Contributing
 
 1. Make a copy of this repository

--- a/README.md
+++ b/README.md
@@ -350,11 +350,39 @@ When defining event filters, note the following:
 - All values are converted to regular expressions for matching
 - Any filter fields can be defined as long as the field exists in the target event
 - A filter must be a hash and nested fields are allowed
-- If a corresponding hash field in the target event is not found, then the remaining value in the target is converted into a string and compared with the value from the filter. The remaining nested fields in the filter are then ignored. This may result in a wider match than expected
+- If a corresponding hash field in the target event is not found, then the remaining value in the target is converted into a string and compared with the value from the filter. The remaining nested fields in the filter are then ignored. This may result in a wider match than expected. Please see section on matching for non hash fields below
 - If there are multiple filters then at least one must match the event
 - All filter fields must match the event fields for a filter to match
 
 In the above example, all create, delete or update entity events to the `course_options` table and `id` matching value `1234` will be logged, or any import entity events to the `courses` table will also be logged.
+
+### Matching on non-hash fields
+
+This is best demonstrated by example.
+
+Given the above event filters and the following target event:
+
+``` Ruby
+  {
+    'entity_table_name' => 'course_options',
+    'event_type' => 'update_entity',
+    'data' => [
+      { 'key' => 'id', 'value' => ['12345'] },
+      { 'key' => 'course_id', 'value' => ['42'] }
+    ]
+  }
+```
+
+Then on matching, there is a one to one correspondence on the `entity_table_name` and `event_type` fields, so these match OK. However, in the target event `data` field there is no hash value, so the `key` field with value of `id` is compared with the whole of the target `data` field converted to a string, and the `value` field with value of `12345` would also be compared with the whole of the target `data` field.
+
+So the comparisons in Ruby would be:
+
+``` Ruby
+  /id/ =~ "[{ 'key' => 'id', 'value' => ['12345'] }, { 'key' => 'course_id', 'value' => ['42'] }]"
+  /12345/ =~ "[{ 'key' => 'id', 'value' => ['12345'] }, { 'key' => 'course_id', 'value' => ['42'] }]"
+```
+
+The fields do match successfully, but note the the first comparison matches `id` on `id` and `course_id` so the match would be wider than expected in some instances.
 
 ## Contributing
 

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -6,6 +6,7 @@ require 'dfe/analytics/event_schema'
 require 'dfe/analytics/fields'
 require 'dfe/analytics/entities'
 require 'dfe/analytics/event'
+require 'dfe/analytics/event_matcher'
 require 'dfe/analytics/analytics_job'
 require 'dfe/analytics/send_events'
 require 'dfe/analytics/load_entities'
@@ -127,12 +128,22 @@ module DfE
       []
     end
 
+    def self.logging
+      Rails.application.config_for(:analytics_logging)
+    rescue RuntimeError
+      {}
+    end
+
     def self.environment
       config.environment
     end
 
     def self.log_only?
       config.log_only
+    end
+
+    def self.logging_enabled?
+      logging[:event_filters]&.any?
     end
 
     def self.async?

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -128,8 +128,8 @@ module DfE
       []
     end
 
-    def self.logging
-      Rails.application.config_for(:analytics_logging)
+    def self.event_debug
+      Rails.application.config_for(:analytics_event_debug)
     rescue RuntimeError
       {}
     end
@@ -142,8 +142,8 @@ module DfE
       config.log_only
     end
 
-    def self.logging_enabled?
-      logging[:event_filters]&.any?
+    def self.event_debug_enabled?
+      event_debug[:event_filters]&.any?
     end
 
     def self.async?

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -128,7 +128,7 @@ module DfE
       []
     end
 
-    def self.event_debug
+    def self.event_debug_filters
       Rails.application.config_for(:analytics_event_debug)
     rescue RuntimeError
       {}
@@ -143,7 +143,7 @@ module DfE
     end
 
     def self.event_debug_enabled?
-      event_debug[:event_filters]&.any?
+      event_debug_filters[:event_filters]&.any?
     end
 
     def self.async?

--- a/lib/dfe/analytics/event_matcher.rb
+++ b/lib/dfe/analytics/event_matcher.rb
@@ -4,7 +4,7 @@ module DfE
     class EventMatcher
       attr_reader :event, :filters
 
-      def initialize(event, filters = DfE::Analytics.event_debug[:event_filters])
+      def initialize(event, filters = DfE::Analytics.event_debug_filters[:event_filters])
         @event = event.with_indifferent_access
         @filters = filters.compact
       end

--- a/lib/dfe/analytics/event_matcher.rb
+++ b/lib/dfe/analytics/event_matcher.rb
@@ -1,0 +1,52 @@
+module DfE
+  module Analytics
+    # Match event against given filters
+    class EventMatcher
+      attr_reader :event, :filters
+
+      def initialize(event, filters = DfE::Analytics.logging[:event_filters])
+        @event = event.with_indifferent_access
+        @filters = filters.compact
+      end
+
+      def matched?
+        filters.any? { |filter| filter_matched?(filter) }
+      end
+
+      private
+
+      def filter_matched?(filter, nested_fields = [])
+        filter.all? do |field, filter_value|
+          fields = nested_fields + [field]
+
+          if filter_value.is_a?(Hash)
+            # Recurse for nested hashes
+            filter_matched?(filter_value, fields)
+          else
+            field_matched?(filter_value, fields)
+          end
+        end
+      end
+
+      def field_matched?(filter_value, nested_fields)
+        event_value = event_value_for(nested_fields)
+
+        regexp = Regexp.new(filter_value)
+
+        regexp.match?(event_value)
+      end
+
+      def event_value_for(nested_fields)
+        # If nested hash fields in a filter don't correspond to hashes in the event THEN
+        # - Convert the remaining value into a string (note: this maybe a whole array)
+        # - Don't dig any deeper into the event on the first non hash value
+        # - Will result in greedy and overzealous match as whole of nested structure compared
+        nested_fields.reduce(event) do |memo, field|
+          break memo.to_s unless memo.is_a?(Hash)
+
+          memo[field]
+        end
+      end
+    end
+  end
+end

--- a/lib/dfe/analytics/event_matcher.rb
+++ b/lib/dfe/analytics/event_matcher.rb
@@ -4,7 +4,7 @@ module DfE
     class EventMatcher
       attr_reader :event, :filters
 
-      def initialize(event, filters = DfE::Analytics.logging[:event_filters])
+      def initialize(event, filters = DfE::Analytics.event_debug[:event_filters])
         @event = event.with_indifferent_access
         @filters = filters.compact
       end

--- a/lib/dfe/analytics/send_events.rb
+++ b/lib/dfe/analytics/send_events.rb
@@ -30,6 +30,8 @@ module DfE
           unless response.success?
             error_message = error_message_for(response.insert_errors)
 
+            Rails.logger.error(error_message)
+
             raise SendEventsError, error_message
           end
         end

--- a/lib/dfe/analytics/send_events.rb
+++ b/lib/dfe/analytics/send_events.rb
@@ -18,25 +18,34 @@ module DfE
           # Use the Rails logger here as the job's logger is set to :warn by default
           Rails.logger.info("DfE::Analytics: #{events.inspect}")
         else
+
+          if DfE::Analytics.logging_enabled?
+            events
+              .select { |event| DfE::Analytics::EventMatcher.new(event).matched? }
+              .each { |event| Rails.logger.info("DfE::Analytics processing: #{event.inspect}") }
+          end
+
           response = DfE::Analytics.events_client.insert(events, ignore_unknown: true)
-          raise SendEventsError, response.insert_errors unless response.success?
+
+          unless response.success?
+            error_message = error_message_for(response.insert_errors)
+
+            raise SendEventsError, error_message
+          end
         end
       end
-    end
 
-    class SendEventsError < StandardError
-      attr_reader :insert_errors
-
-      def initialize(insert_errors)
-        @insert_errors = insert_errors
-
+      def error_message_for(insert_errors)
         message = insert_errors
           .flat_map(&:errors)
           .map { |error| error.try(:message) || error['message'] }
           .compact.join("\n")
 
-        super("Could not insert all events:\n#{message}")
+        "Could not insert all events:\n#{message}"
       end
+    end
+
+    class SendEventsError < StandardError
     end
   end
 end

--- a/lib/dfe/analytics/send_events.rb
+++ b/lib/dfe/analytics/send_events.rb
@@ -19,7 +19,7 @@ module DfE
           Rails.logger.info("DfE::Analytics: #{events.inspect}")
         else
 
-          if DfE::Analytics.logging_enabled?
+          if DfE::Analytics.event_debug_enabled?
             events
               .select { |event| DfE::Analytics::EventMatcher.new(event).matched? }
               .each { |event| Rails.logger.info("DfE::Analytics processing: #{event.inspect}") }

--- a/spec/dfe/analytics/event_matcher_spec.rb
+++ b/spec/dfe/analytics/event_matcher_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe DfE::Analytics::EventMatcher do
   context 'when event is a database update' do
     let(:event) do
       {
-        'entity_table_name' => 'application_choice_details',
+        'entity_table_name' => 'course_options',
         'event_type' => 'update_entity',
         'data' => [
-          { 'key' => 'course_option_id', 'value' => ['12345'] },
-          { 'key' => 'application_form_id', 'value' => ['42'] }
+          { 'key' => 'id', 'value' => ['12345'] },
+          { 'key' => 'course_id', 'value' => ['42'] }
         ]
       }
     end
@@ -20,7 +20,7 @@ RSpec.describe DfE::Analytics::EventMatcher do
             event_filters: [
               {
                 event_type: 'update_entity',
-                entity_table_name: 'application_choice_details'
+                entity_table_name: 'course_options'
               }
             ]
           }
@@ -36,9 +36,9 @@ RSpec.describe DfE::Analytics::EventMatcher do
               event_filters: [
                 {
                   event_type: 'update_entity',
-                  entity_table_name: 'application_choice_details',
+                  entity_table_name: 'course_options',
                   data: {
-                    key: 'course_option_id'
+                    key: 'id'
                   }
                 }
               ]
@@ -56,7 +56,7 @@ RSpec.describe DfE::Analytics::EventMatcher do
               event_filters: [
                 {
                   event_type: 'update_entity',
-                  entity_table_name: 'application_choice_details',
+                  entity_table_name: 'course_options',
                   data: {
                     key: 'foo_bar'
                   }
@@ -77,7 +77,7 @@ RSpec.describe DfE::Analytics::EventMatcher do
             event_filters: [
               {
                 event_type: 'update_entity',
-                entity_table_name: 'application_choice_details'
+                entity_table_name: 'course_options'
               },
               {
                 event_type: 'foo'
@@ -112,7 +112,7 @@ RSpec.describe DfE::Analytics::EventMatcher do
               event_filters: [
                 {
                   event_type: 'create_entity',
-                  entity_table_name: 'application_choice_details'
+                  entity_table_name: 'course_options'
                 },
                 {
                   event_type: 'foo'

--- a/spec/dfe/analytics/event_matcher_spec.rb
+++ b/spec/dfe/analytics/event_matcher_spec.rb
@@ -1,0 +1,131 @@
+RSpec.describe DfE::Analytics::EventMatcher do
+  subject { described_class.new(event, logging[:event_filters]) }
+
+  context 'when event is a database update' do
+    let(:event) do
+      {
+        'entity_table_name' => 'application_choice_details',
+        'event_type' => 'update_entity',
+        'data' => [
+          { 'key' => 'course_option_id', 'value' => ['12345'] },
+          { 'key' => 'application_form_id', 'value' => ['42'] }
+        ]
+      }
+    end
+
+    describe '.matched?' do
+      context 'when the table name and event type matches' do
+        let(:logging) do
+          {
+            event_filters: [
+              {
+                event_type: 'update_entity',
+                entity_table_name: 'application_choice_details'
+              }
+            ]
+          }
+        end
+
+        it 'returns a successful match' do
+          expect(subject).to be_matched
+        end
+
+        context 'when a nested hash key field also matches' do
+          let(:logging) do
+            {
+              event_filters: [
+                {
+                  event_type: 'update_entity',
+                  entity_table_name: 'application_choice_details',
+                  data: {
+                    key: 'course_option_id'
+                  }
+                }
+              ]
+            }
+          end
+
+          it 'returns a successful match' do
+            expect(subject).to be_matched
+          end
+        end
+
+        context 'when a nested hash key field does not match' do
+          let(:logging) do
+            {
+              event_filters: [
+                {
+                  event_type: 'update_entity',
+                  entity_table_name: 'application_choice_details',
+                  data: {
+                    key: 'foo_bar'
+                  }
+                }
+              ]
+            }
+          end
+
+          it 'returns an unsuccessful match' do
+            expect(subject).to_not be_matched
+          end
+        end
+      end
+
+      context 'when 1 out of 2 filters match' do
+        let(:logging) do
+          {
+            event_filters: [
+              {
+                event_type: 'update_entity',
+                entity_table_name: 'application_choice_details'
+              },
+              {
+                event_type: 'foo'
+              }
+            ]
+          }
+        end
+
+        it 'returns a successful match' do
+          expect(subject).to be_matched
+        end
+      end
+
+      context 'when the filter does not match' do
+        let(:logging) do
+          {
+            event_filters: [
+              {
+                event_type: 'foo'
+              }
+            ]
+          }
+        end
+
+        it 'returns an unsuccessful match' do
+          expect(subject).to_not be_matched
+        end
+
+        context 'when 2 out of 2 filters do not match' do
+          let(:logging) do
+            {
+              event_filters: [
+                {
+                  event_type: 'create_entity',
+                  entity_table_name: 'application_choice_details'
+                },
+                {
+                  event_type: 'foo'
+                }
+              ]
+            }
+          end
+
+          it 'returns an unsuccessful match' do
+            expect(subject).to_not be_matched
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/dfe/analytics/send_events_spec.rb
+++ b/spec/dfe/analytics/send_events_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe DfE::Analytics::SendEvents do
         end
       end
 
-      it 'does not log the request when logging disabled' do
+      it 'does not log the request when event_debug disabled' do
         stub_analytics_event_submission
 
         expect(Rails.logger).not_to receive(:info)
@@ -83,11 +83,11 @@ RSpec.describe DfE::Analytics::SendEvents do
       end
     end
 
-    describe 'logging events' do
+    describe 'logging events for event debug' do
       before do
         stub_analytics_event_submission
 
-        allow(DfE::Analytics).to receive(:logging).and_return(logging)
+        allow(DfE::Analytics).to receive(:event_debug).and_return(event_debug)
       end
 
       subject(:perform) do
@@ -97,7 +97,7 @@ RSpec.describe DfE::Analytics::SendEvents do
       end
 
       context 'when the event filter matches' do
-        let(:logging) do
+        let(:event_debug) do
           {
             event_filters: [
               {
@@ -116,7 +116,7 @@ RSpec.describe DfE::Analytics::SendEvents do
       end
 
       context 'when the event filter does not match' do
-        let(:logging) do
+        let(:event_debug) do
           {
             event_filters: [
               {

--- a/spec/dfe/analytics/send_events_spec.rb
+++ b/spec/dfe/analytics/send_events_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe DfE::Analytics::SendEvents do
           end).to have_been_made
         end
       end
+
+      it 'does not log the request when logging disabled' do
+        stub_analytics_event_submission
+
+        expect(Rails.logger).not_to receive(:info)
+
+        DfE::Analytics::Testing.webmock! do
+          described_class.new.perform([event.as_json])
+        end
+      end
     end
 
     context 'when the request is not successful' do
@@ -46,7 +56,7 @@ RSpec.describe DfE::Analytics::SendEvents do
       it 'contains the insert errors' do
         perform
       rescue DfE::Analytics::SendEventsError => e
-        expect(e.insert_errors).to_not be_empty
+        expect(e.message).to_not be_empty
       end
     end
 
@@ -61,6 +71,58 @@ RSpec.describe DfE::Analytics::SendEvents do
         DfE::Analytics::Testing.webmock! do
           described_class.new.perform([event.as_json])
           expect(request).not_to have_been_made
+        end
+      end
+    end
+
+    describe 'logging events' do
+      before do
+        stub_analytics_event_submission
+
+        allow(DfE::Analytics).to receive(:logging).and_return(logging)
+      end
+
+      subject(:perform) do
+        DfE::Analytics::Testing.webmock! do
+          described_class.new.perform([event.as_json])
+        end
+      end
+
+      context 'when the event filter matches' do
+        let(:logging) do
+          {
+            event_filters: [
+              {
+                request_method: 'GET',
+                request_path: '/provider/applications',
+                namespace: 'provider_interface'
+              }
+            ]
+          }
+        end
+
+        it 'logs the event' do
+          expect(Rails.logger).to receive(:info).with("DfE::Analytics processing: #{event.as_json}")
+          perform
+        end
+      end
+
+      context 'when the event filter does not match' do
+        let(:logging) do
+          {
+            event_filters: [
+              {
+                request_method: 'POST',
+                request_path: '/provider/applications',
+                namespace: 'provider_interface'
+              }
+            ]
+          }
+        end
+
+        it 'does not logs the event' do
+          expect(Rails.logger).not_to receive(:info)
+          perform
         end
       end
     end

--- a/spec/dfe/analytics/send_events_spec.rb
+++ b/spec/dfe/analytics/send_events_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe DfE::Analytics::SendEvents do
       before do
         stub_analytics_event_submission
 
-        allow(DfE::Analytics).to receive(:event_debug).and_return(event_debug)
+        allow(DfE::Analytics).to receive(:event_debug_filters).and_return(event_debug_filters)
       end
 
       subject(:perform) do
@@ -97,7 +97,7 @@ RSpec.describe DfE::Analytics::SendEvents do
       end
 
       context 'when the event filter matches' do
-        let(:event_debug) do
+        let(:event_debug_filters) do
           {
             event_filters: [
               {
@@ -116,7 +116,7 @@ RSpec.describe DfE::Analytics::SendEvents do
       end
 
       context 'when the event filter does not match' do
-        let(:event_debug) do
+        let(:event_debug_filters) do
           {
             event_filters: [
               {
@@ -128,7 +128,7 @@ RSpec.describe DfE::Analytics::SendEvents do
           }
         end
 
-        it 'does not logs the event' do
+        it 'does not log the event' do
           expect(Rails.logger).not_to receive(:info)
           perform
         end

--- a/spec/dfe/analytics/send_events_spec.rb
+++ b/spec/dfe/analytics/send_events_spec.rb
@@ -58,6 +58,14 @@ RSpec.describe DfE::Analytics::SendEvents do
       rescue DfE::Analytics::SendEventsError => e
         expect(e.message).to_not be_empty
       end
+
+      it 'logs the error message' do
+        expect(Rails.logger).to receive(:error).with(/Could not insert all events:/)
+
+        perform
+      rescue DfE::Analytics::SendEventsError
+        nil
+      end
     end
 
     context 'when "log_only" is set' do


### PR DESCRIPTION
[Trello-975](https://trello.com/c/rUufn40w/975-investigate-silent-failures-in-dfe-analytics)

Create an events filter for logging, so that we log only the events of interest. This will allow targeted logging for diagnostic and debugging purposes.

The events filter is held in a YAML config.

Event filter example:

``` Yaml
#
# Allows logging of events that match the type and given filters on the fields
#
# All values are converted to regular expressions for matching
#
# Any filter fields can be defined as long as the field exists in the target event
#
# If there are mutiple filters then at least one must match the event
#
# All filter fields must match the event fields for a filter to match
#
shared:
  event_filters:
    -
      type: (create|update|delete)_entity
      entity_table_name: course_options
      data:
        key: id
        value: 12345
``` 