### PR TITLE
Add anonymisation of user_id in the web request event data

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,28 @@ While you’re setting things up consider setting the config options `async:
 false` and `log_only: true` to take ActiveJob and BigQuery (respectively) out
 of the loop.
 
+### 9. Web request event user identifier
+
+#### User identifier
+
+All web request events will add a `user_id` to the event data sent to BigQuery. The `user_id` will only be populated if the controller defines a `current_user` method and it responds to `id`, otherwise the `user_id` will be `nil`.
+
+#### Custom User Identifier
+
+If a field other than `id` is required for the user identifier, then  a custom user identifier proc can be defined in `config/initializers/dfe_analytics.rb`:
+
+```ruby
+DfE::Analytics.config.user_idenitifier = proc { |user| user&.id }
+```
+
+#### User ID anonymisation
+
+The `user_id` in the web request event will not be anonymised by default. This can be changed by updating  the configuration option in `config/initializers/dfe_analytics.rb`:
+
+```ruby
+DfE::Analytics.config.anonymise_web_request_user_id = false
+```
+
 ### Adding specs
 
 #### Testing modes

--- a/README.md
+++ b/README.md
@@ -242,19 +242,21 @@ All web request events will add a `user_id` to the event data sent to BigQuery. 
 
 #### Custom User Identifier
 
-If a field other than `id` is required for the user identifier, then  a custom user identifier proc can be defined in `config/initializers/dfe_analytics.rb`:
+If a field other than `id` is required for the user identifier, then a custom user identifier proc can be defined in `config/initializers/dfe_analytics.rb`:
 
 ```ruby
-DfE::Analytics.config.user_idenitifier = proc { |user| user&.id }
+DfE::Analytics.config.user_identifier = proc { |user| user&.id }
 ```
 
 #### User ID anonymisation
 
-The `user_id` in the web request event will not be anonymised by default. This can be changed by updating  the configuration option in `config/initializers/dfe_analytics.rb`:
+The `user_id` in the web request event will not be anonymised by default. This can be changed by updating the configuration option in `config/initializers/dfe_analytics.rb`:
 
 ```ruby
 DfE::Analytics.config.anonymise_web_request_user_id = false
 ```
+
+Anonymisation of `user_id` would be required if the source field in the schema is in `analytics_pii.yml` so that analysts can join the IDs together. If the `user_id` is not in `analytics_pii.yml` but is in `analytics.yml` then `user_id` anonymisation would *not* be required so that the IDs could still be joined together.
 
 ### Adding specs
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,3 +53,7 @@ en:
             return the identifier for the user. This is useful for systems with
             users that don't use the id field.
           default: proc { |user| user&.id }
+        anonymise_web_request_user_id:
+          description: |
+            Whether to anonymise the user_id field in the web request event.
+          default: false

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -56,6 +56,7 @@ module DfE
         enable_analytics
         environment
         user_identifier
+        anonymise_web_request_user_id
       ]
 
       @config ||= Struct.new(*configurables).new
@@ -64,18 +65,19 @@ module DfE
     def self.configure
       yield(config)
 
-      config.enable_analytics      ||= proc { true }
-      config.bigquery_table_name   ||= ENV['BIGQUERY_TABLE_NAME']
-      config.bigquery_project_id   ||= ENV['BIGQUERY_PROJECT_ID']
-      config.bigquery_dataset      ||= ENV['BIGQUERY_DATASET']
-      config.bigquery_api_json_key ||= ENV['BIGQUERY_API_JSON_KEY']
-      config.bigquery_retries      ||= 3
-      config.bigquery_timeout      ||= 120
-      config.environment           ||= ENV.fetch('RAILS_ENV', 'development')
-      config.log_only              ||= false
-      config.async                 ||= true
-      config.queue                 ||= :default
-      config.user_identifier       ||= proc { |user| user&.id }
+      config.enable_analytics              ||= proc { true }
+      config.bigquery_table_name           ||= ENV['BIGQUERY_TABLE_NAME']
+      config.bigquery_project_id           ||= ENV['BIGQUERY_PROJECT_ID']
+      config.bigquery_dataset              ||= ENV['BIGQUERY_DATASET']
+      config.bigquery_api_json_key         ||= ENV['BIGQUERY_API_JSON_KEY']
+      config.bigquery_retries              ||= 3
+      config.bigquery_timeout              ||= 120
+      config.environment                   ||= ENV.fetch('RAILS_ENV', 'development')
+      config.log_only                      ||= false
+      config.async                         ||= true
+      config.queue                         ||= :default
+      config.user_identifier               ||= proc { |user| user&.id }
+      config.anonymise_web_request_user_id ||= false
     end
 
     def self.initialize!

--- a/lib/dfe/analytics/event.rb
+++ b/lib/dfe/analytics/event.rb
@@ -55,33 +55,25 @@ module DfE
       end
 
       def with_user(user)
-        @event_hash.merge!(
-          user_id: DfE::Analytics.user_identifier(user)
-        )
+        @event_hash.merge!(user_id: user_identifier_for(user))
 
         self
       end
 
       def with_namespace(namespace)
-        @event_hash.merge!(
-          namespace: namespace
-        )
+        @event_hash.merge!(namespace: namespace)
 
         self
       end
 
       def with_entity_table_name(table_name)
-        @event_hash.merge!(
-          entity_table_name: table_name
-        )
+        @event_hash.merge!(entity_table_name: table_name)
 
         self
       end
 
       def with_data(hash)
-        @event_hash.deep_merge!({
-                                  data: hash_to_kv_pairs(hash)
-                                })
+        @event_hash.deep_merge!(data: hash_to_kv_pairs(hash))
 
         self
       end
@@ -132,6 +124,13 @@ module DfE
 
       def ensure_utf8(str)
         str&.scrub
+      end
+
+      def user_identifier_for(user)
+        user_id = DfE::Analytics.user_identifier(user)
+        user_id = DfE::Analytics.anonymise(user_id) if user_id.present? && DfE::Analytics.config.anonymise_web_request_user_id
+
+        user_id
       end
     end
   end


### PR DESCRIPTION

[Trello-975](https://trello.com/c/Q9WmHE1g/1004-teaching-vacancies-userid-field-is-blank-in-events-table-not-sure-how-to-configure-this-in-dfe-analytics)

Add anonymisation of user_id in the web request event data
- Make this configurable through dfe analytics config
- Update README to explain anonymisation and custom user identifier