### PR TITLE
Send request events for cached pages with rack middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,13 +401,12 @@ For example, if a projects uses standard rails page caching, then a custom `rack
 
 
 ```ruby
-DfE::Analytics.config.rack_page_cached = do |rack_env|
-  def path
-    File.join(Rails.application.config.root, 'public/cached_pages')
-  end
+DfE::Analytics.config.rack_page_cached = proc do |rack_env|
+  def path; File.join(Rails.root, 'public/cached_pages'); end
 
   Rails.application.config.action_controller.perform_caching &&
     ActionDispatch::FileHandler.new(path).attempt(rack_env)
+  end
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -389,6 +389,35 @@ So the comparisons in Ruby would be:
 
 The fields do match successfully, but note the the first comparison matches `id` on `id` and `course_id` so the match would be wider than expected in some instances.
 
+## Page Caching
+
+Any page visit in the App will result in a web request event being sent to Big Query. The event is automatically sent by the Controller after action callback `trigger_request_event`. However, cached pages that are served from rack middleware return early and therefore do not execute any actions in the controller. This means that any cached page visits handled by rack middleware do NOT result in a web request event being sent to Big Query.
+
+To overcome this issue the `dfe-analytics` gem allows the sending of web request events from rack middleware, before the cached page is served, through configuration.
+
+If a page is cached by rack middleware, then a custom `rack_page_cached` proc must be defined in `config/initializers/dfe_analytics.rb`, that returns a boolean indicating whether the page is cached by rack.
+
+For example, if a projects uses standard rails page caching, then a custom `rack_page_cached` proc  can be defined in `config/initializers/dfe_analytics.rb` as follows:
+
+
+```ruby
+DfE::Analytics.config.rack_page_cached = do |rack_env|
+  def path
+    File.join(Rails.application.config.root, 'public/cached_pages')
+  end
+
+  Rails.application.config.action_controller.perform_caching &&
+    ActionDispatch::FileHandler.new(path).attempt(rack_env)
+end
+```
+
+**IMPORTANT**
+
+`rack_page_cached` must only return `true` if a specific request for a page is in the cache and the cached page is served by rack middleware. Otherwise web request events might be sent twice, resulting in inaccurate information in Big Query.
+
+Please note that page caching is project specific and each project must carefully consider  how pages are cached and whether web request events are sent. If page caching on your project results in web request events not being sent, and the above does not resolve the issue, then please get in touch with the data insights team though slack.
+
+
 ## Contributing
 
 1. Make a copy of this repository

--- a/README.md
+++ b/README.md
@@ -391,7 +391,9 @@ The fields do match successfully, but note the the first comparison matches `id`
 
 ## Page Caching
 
-Any page visit in the App will result in a web request event being sent to Big Query. The event is automatically sent by the Controller after action callback `trigger_request_event`. However, cached pages that are served from rack middleware return early and therefore do not execute any actions in the controller. This means that any cached page visits handled by rack middleware do NOT result in a web request event being sent to Big Query.
+This section is applicable if your App uses standard Rails rack middleware page caching. For other forms of page caching please read the IMPORTANT note below. If your App does not cache any pages, you can skip this section.
+
+Any page visit in the App will result in a web request event being sent to BigQuery. The event is automatically sent by the Controller after action callback `trigger_request_event`. However, cached pages that are served from rack middleware return early and therefore do not execute any actions in the controller. This means that any cached page visits handled by rack middleware do NOT result in a web request event being sent to BigQuery.
 
 To overcome this issue the `dfe-analytics` gem allows the sending of web request events from rack middleware, before the cached page is served, through configuration.
 
@@ -402,19 +404,16 @@ For example, if a projects uses standard rails page caching, then a custom `rack
 
 ```ruby
 DfE::Analytics.config.rack_page_cached = proc do |rack_env|
-  def path; File.join(Rails.root, 'public/cached_pages'); end
-
-  Rails.application.config.action_controller.perform_caching &&
-    ActionDispatch::FileHandler.new(path).attempt(rack_env)
-  end
+   Rails.application.config.action_controller.perform_caching &&
+   ActionDispatch::FileHandler.new(Rails.root.join("public/cached_pages").to_s).attempt(rack_env)
 end
 ```
 
 **IMPORTANT**
 
-`rack_page_cached` must only return `true` if a specific request for a page is in the cache and the cached page is served by rack middleware. Otherwise web request events might be sent twice, resulting in inaccurate information in Big Query.
+`rack_page_cached` must only return `true` if a specific request for a page is in the cache and the cached page is served by rack middleware. Otherwise web request events might be sent twice, resulting in inaccurate information in BigQuery.
 
-Please note that page caching is project specific and each project must carefully consider  how pages are cached and whether web request events are sent. If page caching on your project results in web request events not being sent, and the above does not resolve the issue, then please get in touch with the data insights team though slack.
+Please note that page caching is project specific and each project must carefully consider how pages are cached and whether web request events are sent. If page caching on your project results in web request events not being sent, and the above does not resolve the issue, then please get in touch with the data insights team though slack.
 
 
 ## Contributing

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,3 +57,9 @@ en:
           description: |
             Whether to anonymise the user_id field in the web request event.
           default: false
+        rack_page_cached:
+          description: |
+            A proc which will be called with the rack env, and which should
+            return boolean indicating whether the page is cached and will be
+            served by rack middleware.
+          default: proc { |_rack_env| false }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,6 @@ en:
         rack_page_cached:
           description: |
             A proc which will be called with the rack env, and which should
-            return boolean indicating whether the page is cached and will be
-            served by rack middleware.
+            return a boolean indicating whether the page is cached and will
+            be served by rack middleware.
           default: proc { |_rack_env| false }

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -14,6 +14,7 @@ require 'dfe/analytics/load_entity_batch'
 require 'dfe/analytics/requests'
 require 'dfe/analytics/version'
 require 'dfe/analytics/middleware/request_identity'
+require 'dfe/analytics/middleware/send_cached_page_request_event'
 require 'dfe/analytics/railtie'
 
 module DfE
@@ -58,6 +59,7 @@ module DfE
         environment
         user_identifier
         anonymise_web_request_user_id
+        rack_page_cached
       ]
 
       @config ||= Struct.new(*configurables).new
@@ -79,6 +81,7 @@ module DfE
       config.queue                         ||= :default
       config.user_identifier               ||= proc { |user| user&.id }
       config.anonymise_web_request_user_id ||= false
+      config.rack_page_cached              ||= proc { |_rack_env| false }
     end
 
     def self.initialize!
@@ -214,6 +217,10 @@ module DfE
 
     def self.user_identifier(user)
       config.user_identifier.call(user)
+    end
+
+    def self.rack_page_cached?(rack_env)
+      config.rack_page_cached.call(rack_env)
     end
   end
 end

--- a/lib/dfe/analytics/middleware/send_cached_page_request_event.rb
+++ b/lib/dfe/analytics/middleware/send_cached_page_request_event.rb
@@ -1,7 +1,7 @@
 module DfE
   module Analytics
     module Middleware
-      # Middleware to send request event to big query if page cached by rack
+      # Middleware to send request event to BigQuery if page cached by rack
       # In Rails a cached page is commonly served by ActionDispatch:Static middleware
       # This middleware must be inserted before ActionDispatch:Static to intercept request
       class SendCachedPageRequestEvent
@@ -31,7 +31,7 @@ module DfE
         end
 
         def response
-          ActionDispatch::Response.new(200, 'Content-Type' => 'text/html')
+          ActionDispatch::Response.new(304, 'Content-Type' => 'text/html; charset=utf-8')
         end
       end
     end

--- a/lib/dfe/analytics/middleware/send_cached_page_request_event.rb
+++ b/lib/dfe/analytics/middleware/send_cached_page_request_event.rb
@@ -1,0 +1,39 @@
+module DfE
+  module Analytics
+    module Middleware
+      # Middleware to send request event to big query if page cached by rack
+      # In Rails a cached page is commonly served by ActionDispatch:Static middleware
+      # This middleware must be inserted before ActionDispatch:Static to intercept request
+      class SendCachedPageRequestEvent
+        def initialize(app)
+          @app = app
+        end
+
+        def call(env)
+          # Detect if page is Cached and send request event accordingly
+          send_request_event(env) if DfE::Analytics.rack_page_cached?(env)
+
+          @app.call(env)
+        end
+
+        private
+
+        def send_request_event(env)
+          request = ActionDispatch::Request.new(env)
+
+          request_event = DfE::Analytics::Event.new
+                                               .with_type('web_request')
+                                               .with_request_details(request)
+                                               .with_response_details(response)
+                                               .with_request_uuid(request.request_id)
+
+          DfE::Analytics::SendEvents.do([request_event.as_json])
+        end
+
+        def response
+          ActionDispatch::Response.new(200, 'Content-Type' => 'text/html')
+        end
+      end
+    end
+  end
+end

--- a/lib/dfe/analytics/railtie.rb
+++ b/lib/dfe/analytics/railtie.rb
@@ -11,6 +11,9 @@ module DfE
 
       initializer 'dfe.analytics.insert_middleware' do |app|
         app.config.middleware.use DfE::Analytics::Middleware::RequestIdentity
+
+        app.config.middleware.insert_before \
+          ActionDispatch::Static, DfE::Analytics::Middleware::SendCachedPageRequestEvent
       end
 
       initializer 'dfe.analytics.logger' do

--- a/spec/dfe/analytics/middleware/send_cached_page_request_event_spec.rb
+++ b/spec/dfe/analytics/middleware/send_cached_page_request_event_spec.rb
@@ -15,8 +15,10 @@ RSpec.describe DfE::Analytics::Middleware::SendCachedPageRequestEvent do
     before do
       allow(DfE::Analytics).to receive(:rack_page_cached?).with(env).and_return(is_cached)
       allow(ActionDispatch::Request).to receive(:new).with(env).and_return(request)
-      allow(ActionDispatch::Response).to receive(:new).with(200, 'Content-Type' => 'text/html').and_return(response)
       allow(DfE::Analytics::Event).to receive(:new).and_return(event)
+
+      allow(ActionDispatch::Response)
+        .to receive(:new).with(304, 'Content-Type' => 'text/html; charset=utf-8').and_return(response)
 
       allow(event).to receive(:with_type).with('web_request').and_return(event)
       allow(event).to receive(:with_request_details).with(request).and_return(event)

--- a/spec/dfe/analytics/middleware/send_cached_page_request_event_spec.rb
+++ b/spec/dfe/analytics/middleware/send_cached_page_request_event_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe DfE::Analytics::Middleware::SendCachedPageRequestEvent do
+  let(:app) { double('app') }
+
+  subject { described_class.new(app) }
+
+  describe '#call' do
+    let(:env) { { 'PATH_INFO' => '/path/to/page', 'REQUEST_METHOD' => 'GET' } }
+    let(:request) { instance_double(ActionDispatch::Request, request_id: '123') }
+    let(:response) { instance_double(ActionDispatch::Response) }
+    let(:event) { instance_double(DfE::Analytics::Event) }
+    let(:is_cached) { false }
+
+    before do
+      allow(DfE::Analytics).to receive(:rack_page_cached?).with(env).and_return(is_cached)
+      allow(ActionDispatch::Request).to receive(:new).with(env).and_return(request)
+      allow(ActionDispatch::Response).to receive(:new).with(200, 'Content-Type' => 'text/html').and_return(response)
+      allow(DfE::Analytics::Event).to receive(:new).and_return(event)
+
+      allow(event).to receive(:with_type).with('web_request').and_return(event)
+      allow(event).to receive(:with_request_details).with(request).and_return(event)
+      allow(event).to receive(:with_response_details).with(response).and_return(event)
+      allow(event).to receive(:with_request_uuid).with(request.request_id).and_return(event)
+    end
+
+    context 'when the page is cached' do
+      let(:is_cached) { true }
+
+      it 'sends a request event to BigQuery and calls next middleware' do
+        expect(app).to receive(:call).with(env)
+        expect(DfE::Analytics::SendEvents).to receive(:do).with([event.as_json])
+        subject.call(env)
+      end
+    end
+
+    context 'when the page is not cached' do
+      let(:is_cached) { false }
+
+      it 'does not send a request event to BigQuery and calls next middleware' do
+        expect(app).to receive(:call).with(env)
+        expect(DfE::Analytics::SendEvents).not_to receive(:do)
+        subject.call(env)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Trello card
[Trello-1058](https://trello.com/c/6b49g4yk/1058-bug-git-website-home-page-views-in-ga-much-greater-than-in-events-table-in-bq)

### Context
We have a big inconsistency tracking homepage visits on the GiT website through BigQuery.

BQ Count: 1637 vs GA Count: 65,263. Please see ticket for details.

After some troubleshooting we found that there is page caching of static pages, the homepage being a static page.

GiT website uses [rack-page_caching](https://github.com/pkorenev/rack-page_caching) GEM, that implements caching through rack middleware.

The DfE Analytics syncs web request events with a controller after action callback.

Cached pages are served by rack middleware, returning early and therefore do not execute any actions in the controller. This means that any cached page visits handled by rack middleware do NOT result in a web request event being sent to Big Query.

### Changes proposed in this pull request and Guidance

The type and method of caching done by a Rails App is a choice.

The most standard way for rails to cache pages, is by using `actionpack-page_caching` (Or the GEM we use in git `rack-page_caching`). These save cached pages to the public directory.

In Rails there is a standard `ActionDispatch::Static middleware`, normally very high up in the stack. It checks for the presence of the requested asset (Eg Javascript, Image, Page etc), and serves the asset from the file cache if it is present (Normally from public but this is configurable).

No doubt there are other caching GEMs (Both Rails and Rack), Eg `Rack::Cache`, that serve from a memory cache, such as memcache or Redis.

There are also other caching mechanisms such as Action, Fragment, Russian Doll Caching, that serve the cached page from the controller, in which case we don't have a problem with sending of the big query event.

Also adding a header to the request to indicate a cached page, has to be done by the client. The client doesn't know if a requested page is cached, unless there is some content on the page that indicates it is cached or something in the session cookie, and then only after the page is returned 

There's also the question of whether the cached page is served from middleware or the controller.

So our specific issue on GiT is a static cached page served by  `ActionDispatch::Static` middleware from file. If the page is cached then we need to send the BQ event before hitting `ActionDispatch::Static`. This is the most common type of caching IMO anyway.

Suggestions for adding to DfE Analytics GEM:

- We need to make it obvious that this feature is for only when a cached page is served by rack middleware and not the application controller.
-  DfE Analytics will add middleware (eg `SendCachedPageRequestEvent`) before `ActionDispatch::Static` to handle the sending of the event to BQ.
- The Analytics GEM requires a configurable custom proc methods (In `config/initializers/dfe_analytics.rb`):
`rack_page_cached`. This proc should return a boolean indicating whether the page is cached by rack

Having a project configurable proc removes the assumptions about the type and method of caching, allowing the project full control of when to send the web request event to Big Query.


