### PR TITLE
Add event details to send event error log message

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,12 @@ When defining event filters, note the following:
 
 In the above example, all create, delete or update entity events to the `course_options` table and `id` matching value `1234` will be logged, or any import entity events to the `courses` table will also be logged.
 
+**IMPORTANT**:
+
+Please ensure you are not logging sensitive data to debug. Your project should define blocklist and pii (personally identifiable information) fields, so these should prevent any sensitive data appearing in the events.
+
+Logging to debug should only be used for diagnosis/investigation purposes. Once diagnosis/investigation is complete, the logging to debug should be removed.
+
 ### Matching on non-hash fields
 
 This is best demonstrated by example.


### PR DESCRIPTION
[Trello-975](https://trello.com/c/rUufn40w/975-investigate-silent-failures-in-dfe-analytics)

When an error occurs in `DfE::Analytics::SendEvents` calling the events insert API, the error responses are logged, but the events that caused the error are not included in the log message.

Add the events to the error log message to help with error diagnosis.

Also add advice for event debugging regarding sensitive data.