### PR TITLE
Refer serious misconduct / Apply for QTS unable to upgrade to DfE Analytics GEM (v1.8.0)

### DIFF
--- a/lib/dfe/analytics/railtie.rb
+++ b/lib/dfe/analytics/railtie.rb
@@ -12,8 +12,10 @@ module DfE
       initializer 'dfe.analytics.insert_middleware' do |app|
         app.config.middleware.use DfE::Analytics::Middleware::RequestIdentity
 
-        app.config.middleware.insert_before \
-          ActionDispatch::Static, DfE::Analytics::Middleware::SendCachedPageRequestEvent
+        if ENV['RAILS_SERVE_STATIC_FILES'].present?
+          app.config.middleware.insert_before \
+            ActionDispatch::Static, DfE::Analytics::Middleware::SendCachedPageRequestEvent
+        end
       end
 
       initializer 'dfe.analytics.logger' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 ENV['RAILS_ENV'] = 'test'
 ENV['SUPPRESS_DFE_ANALYTICS_INIT'] = 'true'
+ENV['RAILS_SERVE_STATIC_FILES'] = 'true'
 
 require_relative '../spec/dummy/config/environment'
 require 'debug'


### PR DESCRIPTION
[Trello-1107](https://trello.com/c/fBBPetwX/1107-refer-serious-misconduct-apply-for-qts-unable-to-upgrade-to-latest-dfe-analytics-gem)

The problem is mainly seen during the rails assets:precompile step while the docker container is being built. This article [here](https://glennjon.es/2022/07/02/fixing-no-such-middleware-to-insert-before-error-during-docker-build.html)  explains it well:

Three options considered to address the problem:

1. Set env variable `RAILS_SERVE_STATIC_FILES=true` for precompile in the Dockerfile:
    For example:
   ```
    RUN RAILS_SERVE_STATIC_FILES=true SECRET_KEY_BASE=dummyvalue rails assets:precompile
    ```
2. Catch the Ruby run time error on the insert middleware and ignore if it matches the expected error message.
    For example:
    ```
    begin
      app.config.middleware.insert_before \
      ActionDispatch::Static,
      DfE::Analytics::Middleware::SendCachedPageRequestEvent

    rescue RuntimeError => e
       error_message = 'No such middleware to insert before: ActionDispatch::Static'

       raise e unless Regexp.new(error_message, 'i').match?(e.message.squish)
    end
    ```
3. Only add the DfE middleware if RAILS_SERVE_STATIC_FILES=true
    ```
    if ENV['RAILS_SERVE_STATIC_FILES'].present?
      app.config.middleware.insert_before \
      ActionDispatch::Static,
      DfE::Analytics::Middleware::SendCachedPageRequestEvent
    end
    ```
So Rails will always have ActionDispatch::Static apart from when it doesn't ! (When the container is being built or when `RAILS_SERVE_STATIC_FILES=true`). So 3 maybe is the safest option.
I'm not entirely sure when `RAILS_SERVE_STATIC_FILES=false` will be set. Maybe when static assets are served from a reverse proxy web server like nginx. Needless to say,  when that this is the case, then we wouldn't support any web pages that are cached though different mechanisms other that Rails and even then it must be done though ActionDispatch::Static middleware.
The GIT Website works as `RAILS_SERVE_STATIC_FILES=false` is set in the Dockerfile, whereas
Refer serious misconduct, Register and Apply for TT, Apply for QTS don't set  RAILS_SERVE_STATIC_FILES in the Dockerfile, but I see it set in Terraform, so (3) should cover all the cases I see failing.