### PR TITLE
v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,20 @@
 # Changelog
 
-## [v1.8.0](https://github.com/DFE-Digital/dfe-analytics/tree/v1.8.0) (2023-04-04)
+## [v1.9.0](https://github.com/DFE-Digital/dfe-analytics/tree/v1.9.0) (2023-04-26)
 
-[Full Changelog](https://github.com/DFE-Digital/dfe-analytics/compare/v1.7.0...v1.8.0)
+[Full Changelog](https://github.com/DFE-Digital/dfe-analytics/compare/v1.8.0...v1.9.0)
 
 **Merged pull requests:**
 
+- Refer serious misconduct / Apply for QTS unable to upgrade to DfE Analytics GEM \(v1.8.0\) [\#70](https://github.com/DFE-Digital/dfe-analytics/pull/70) ([asatwal](https://github.com/asatwal))
 - Send request events for cached pages with rack middleware [\#67](https://github.com/DFE-Digital/dfe-analytics/pull/67) ([asatwal](https://github.com/asatwal))
 - Update advice on queue config and running imports [\#65](https://github.com/DFE-Digital/dfe-analytics/pull/65) ([asatwal](https://github.com/asatwal))
 - Add anonymisation of user\_id in the web request event data [\#64](https://github.com/DFE-Digital/dfe-analytics/pull/64) ([asatwal](https://github.com/asatwal))
 - Log Matched Events [\#63](https://github.com/DFE-Digital/dfe-analytics/pull/63) ([asatwal](https://github.com/asatwal))
+
+## [v1.8.0](https://github.com/DFE-Digital/dfe-analytics/tree/v1.8.0) (2023-04-04)
+
+[Full Changelog](https://github.com/DFE-Digital/dfe-analytics/compare/v1.7.0...v1.8.0)
 
 ## [v1.7.0](https://github.com/DFE-Digital/dfe-analytics/tree/v1.7.0) (2023-02-24)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dfe-analytics (1.8.0)
+    dfe-analytics (1.9.0)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 

--- a/lib/dfe/analytics/version.rb
+++ b/lib/dfe/analytics/version.rb
@@ -2,6 +2,6 @@
 
 module DfE
   module Analytics
-    VERSION = '1.8.0'
+    VERSION = '1.9.0'
   end
 end


### PR DESCRIPTION
Fixes: Refer serious misconduct / Apply for QTS unable to upgrade to DfE Analytics GEM (v1.8.0)