### PR TITLE
Minor wording fixes

### DIFF
--- a/lib/dfe/analytics/tasks/fields.rake
+++ b/lib/dfe/analytics/tasks/fields.rake
@@ -1,6 +1,6 @@
 namespace :dfe do
   namespace :analytics do
-    desc 'Generate a new field blocklist containing all the fields not listed for sending to Bigquery'
+    desc 'Identify issues with the analytics fields listings'
     task check: :environment do
       DfE::Analytics::Fields.check!
     end

--- a/lib/generators/dfe/analytics/templates/fields_spec.rb
+++ b/lib/generators/dfe/analytics/templates/fields_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'DfE::Analytics fields' do
       New database field detected! You need to decide whether or not to send it
       to BigQuery. To send, add it to config/analytics.yml. To ignore, run:
 
-      bundle exec rails bigquery:regenerate_blocklist
+      bundle exec rails dfe:analytics:regenerate_blocklist
 
       New fields: #{unlisted_fields.inspect}
     HEREDOC
@@ -20,7 +20,7 @@ RSpec.describe 'DfE::Analytics fields' do
     failure_message = <<~HEREDOC
       Database field removed! Please remove it from analytics.yml and then run
 
-      bundle exec rails bigquery:regenerate_blocklist
+      bundle exec rails dfe:analytics:regenerate_blocklist
 
       Removed fields: #{surplus_fields.inspect}
     HEREDOC


### PR DESCRIPTION
When going through the gem's codebase, I noticed a couple of places where the wording was incorrect or needed to be upgraded:

- Wrong task description matching another rake task.
- A command message displaying a deprecated interface call for a rake task.