### PR TITLE
Send config events

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,18 @@ DfE::Analytics.config.anonymise_web_request_user_id = false
 
 Anonymisation of `user_id` would be required if the source field in the schema is in `analytics_pii.yml` so that analysts can join the IDs together. If the `user_id` is not in `analytics_pii.yml` but is in `analytics.yml` then `user_id` anonymisation would *not* be required so that the IDs could still be joined together.
 
+### Data Anonymisation Algorithm
+
+Generally all PII data should be anonymised, including data that directly or indirect references PII, for example database IDs.
+
+The `dfe-analytics` gem also anonymises such data, if it is configured to do so. If you are anonymising database IDs in your code (in custom events for example), then you should uses the same hashing algorithm for anonymisation that the gem uses.
+
+The following method should be used in your code for anonymisation:
+
+```ruby
+DfE::Analytics.anonymise(value)
+```
+
 ### Adding specs
 
 #### Testing modes
@@ -432,8 +444,11 @@ Please note that page caching is project specific and each project must carefull
 > 	It could be nice to have tests to prove that connectivity to GCP still works after an update, but we aren't setup for that yet.
 3. (Optional) Verify committed `CHANGELOG.md` changes and alter if necessary: `git show`
 4. Push the branch: `git push origin v${NEW_VERSION}-release`, e.g. `git push origin v1.3.0-release`
-5. Push the tags: `git push --tags`
-6. Cut a PR on GitHub with the label `version-release`, and merge once approved
+5. Cut a PR on GitHub with the label `version-release`, and wait for approval 
+6. Once the PR is approved push the tags, immediately prior to merging: `git push --tags`
+7. Merge the PR.
+
+IMPORTANT:  Pushing the tags will immediately make the release available even on a unmerged branch. Therefore, push the tags to Github only when the PR is approved and immediately prior to merging the PR.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **👉 Send every web request and database update to BigQuery**
 
-**✋ Skip or anonymise fields containing PII**
+**✋ Skip or pseudonymise fields containing PII**. For an explanation of pseudonymisation, see [ICO Guidance](https://ico.org.uk/media/about-the-ico/consultations/4019579/chapter-3-anonymisation-guidance.pdf)
 
 **✌️  Configure and forget**
 
@@ -250,26 +250,26 @@ If a field other than `id` is required for the user identifier, then a custom us
 DfE::Analytics.config.user_identifier = proc { |user| user&.id }
 ```
 
-#### User ID anonymisation
+#### User ID pseudonymisation
 
-The `user_id` in the web request event will not be anonymised by default. This can be changed by updating the configuration option in `config/initializers/dfe_analytics.rb`:
+The `user_id` in the web request event will not be pseudonymised by default. This can be changed by updating the configuration option in `config/initializers/dfe_analytics.rb`:
 
 ```ruby
-DfE::Analytics.config.anonymise_web_request_user_id = false
+DfE::Analytics.config.pseudonymise_web_request_user_id = false
 ```
 
-Anonymisation of `user_id` would be required if the source field in the schema is in `analytics_pii.yml` so that analysts can join the IDs together. If the `user_id` is not in `analytics_pii.yml` but is in `analytics.yml` then `user_id` anonymisation would *not* be required so that the IDs could still be joined together.
+Pseudonymisation of `user_id` would be required if the source field in the schema is in `analytics_pii.yml` so that analysts can join the IDs together. If the `user_id` is not in `analytics_pii.yml` but is in `analytics.yml` then `user_id` pseudonymisation would *not* be required so that the IDs could still be joined together.
 
-### Data Anonymisation Algorithm
+### Data Pseudonymisation Algorithm
 
-Generally all PII data should be anonymised, including data that directly or indirect references PII, for example database IDs.
+Generally all PII data should be pseudonymised, including data that directly or indirect references PII, for example database IDs.
 
-The `dfe-analytics` gem also anonymises such data, if it is configured to do so. If you are anonymising database IDs in your code (in custom events for example), then you should use the same hashing algorithm for anonymisation that the gem uses in order to allow joining of anonymised data across different database tables.
+The `dfe-analytics` gem also pseudonymises such data, if it is configured to do so. If you are pseudonymising database IDs in your code (in custom events for example), then you should use the same hashing algorithm for pseudonymisation that the gem uses in order to allow joining of pseudonymised data across different database tables.
 
-The following method should be used in your code for anonymisation:
+The following method should be used in your code for pseudonymisation:
 
 ```ruby
-DfE::Analytics.anonymise(value)
+DfE::Analytics.pseudonymise(value)
 ```
 
 ### Adding specs

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Anonymisation of `user_id` would be required if the source field in the schema i
 
 Generally all PII data should be anonymised, including data that directly or indirect references PII, for example database IDs.
 
-The `dfe-analytics` gem also anonymises such data, if it is configured to do so. If you are anonymising database IDs in your code (in custom events for example), then you should uses the same hashing algorithm for anonymisation that the gem uses.
+The `dfe-analytics` gem also anonymises such data, if it is configured to do so. If you are anonymising database IDs in your code (in custom events for example), then you should use the same hashing algorithm for anonymisation that the gem uses in order to allow joining of anonymised data across different database tables.
 
 The following method should be used in your code for anonymisation:
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,9 +53,9 @@ en:
             return the identifier for the user. This is useful for systems with
             users that don't use the id field.
           default: proc { |user| user&.id }
-        anonymise_web_request_user_id:
+        pseudonymise_web_request_user_id:
           description: |
-            Whether to anonymise the user_id field in the web request event.
+            Whether to pseudonymise the user_id field in the web request event.
           default: false
         rack_page_cached:
           description: |

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -104,8 +104,6 @@ module DfE
           model.include(DfE::Analytics::Entities)
         end
       end
-
-      DfE::Analytics::Initialise.trigger_initialise_event
     rescue ActiveRecord::PendingMigrationError
       Rails.logger.info('Database requires migration; DfE Analytics not initialized')
     rescue ActiveRecord::ActiveRecordError

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -12,6 +12,7 @@ require 'dfe/analytics/send_events'
 require 'dfe/analytics/load_entities'
 require 'dfe/analytics/load_entity_batch'
 require 'dfe/analytics/requests'
+require 'dfe/analytics/initialise'
 require 'dfe/analytics/version'
 require 'dfe/analytics/middleware/request_identity'
 require 'dfe/analytics/middleware/send_cached_page_request_event'
@@ -103,6 +104,9 @@ module DfE
           model.include(DfE::Analytics::Entities)
         end
       end
+
+      DfE::Analytics::Initialise.trigger_initialise_event
+
     rescue ActiveRecord::PendingMigrationError
       Rails.logger.info('Database requires migration; DfE Analytics not initialized')
     rescue ActiveRecord::ActiveRecordError

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -106,7 +106,6 @@ module DfE
       end
 
       DfE::Analytics::Initialise.trigger_initialise_event
-
     rescue ActiveRecord::PendingMigrationError
       Rails.logger.info('Database requires migration; DfE Analytics not initialized')
     rescue ActiveRecord::ActiveRecordError
@@ -185,6 +184,7 @@ module DfE
     end
 
     def self.anonymise(value)
+      # Google SQL equivalent of this is TO_HEX(SHA256(value))
       Digest::SHA2.hexdigest(value.to_s)
     end
 

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -59,7 +59,7 @@ module DfE
         enable_analytics
         environment
         user_identifier
-        anonymise_web_request_user_id
+        pseudonymise_web_request_user_id
         rack_page_cached
       ]
 
@@ -69,20 +69,20 @@ module DfE
     def self.configure
       yield(config)
 
-      config.enable_analytics              ||= proc { true }
-      config.bigquery_table_name           ||= ENV['BIGQUERY_TABLE_NAME']
-      config.bigquery_project_id           ||= ENV['BIGQUERY_PROJECT_ID']
-      config.bigquery_dataset              ||= ENV['BIGQUERY_DATASET']
-      config.bigquery_api_json_key         ||= ENV['BIGQUERY_API_JSON_KEY']
-      config.bigquery_retries              ||= 3
-      config.bigquery_timeout              ||= 120
-      config.environment                   ||= ENV.fetch('RAILS_ENV', 'development')
-      config.log_only                      ||= false
-      config.async                         ||= true
-      config.queue                         ||= :default
-      config.user_identifier               ||= proc { |user| user&.id }
-      config.anonymise_web_request_user_id ||= false
-      config.rack_page_cached              ||= proc { |_rack_env| false }
+      config.enable_analytics                 ||= proc { true }
+      config.bigquery_table_name              ||= ENV['BIGQUERY_TABLE_NAME']
+      config.bigquery_project_id              ||= ENV['BIGQUERY_PROJECT_ID']
+      config.bigquery_dataset                 ||= ENV['BIGQUERY_DATASET']
+      config.bigquery_api_json_key            ||= ENV['BIGQUERY_API_JSON_KEY']
+      config.bigquery_retries                 ||= 3
+      config.bigquery_timeout                 ||= 120
+      config.environment                      ||= ENV.fetch('RAILS_ENV', 'development')
+      config.log_only                         ||= false
+      config.async                            ||= true
+      config.queue                            ||= :default
+      config.user_identifier                  ||= proc { |user| user&.id }
+      config.pseudonymise_web_request_user_id ||= false
+      config.rack_page_cached                 ||= proc { |_rack_env| false }
     end
 
     def self.initialize!
@@ -180,10 +180,14 @@ module DfE
       allowed_attributes = attributes.slice(*exportable_attrs&.map(&:to_s))
       obfuscated_attributes = attributes.slice(*exportable_pii_attrs&.map(&:to_s))
 
-      allowed_attributes.deep_merge(obfuscated_attributes.transform_values { |value| anonymise(value) })
+      allowed_attributes.deep_merge(obfuscated_attributes.transform_values { |value| pseudonymise(value) })
     end
 
     def self.anonymise(value)
+      pseudonymise(value)
+    end
+
+    def self.pseudonymise(value)
       # Google SQL equivalent of this is TO_HEX(SHA256(value))
       Digest::SHA2.hexdigest(value.to_s)
     end

--- a/lib/dfe/analytics/event.rb
+++ b/lib/dfe/analytics/event.rb
@@ -124,7 +124,7 @@ module DfE
       end
 
       def anonymised_user_agent_and_ip(rack_request)
-        DfE::Analytics.anonymise(rack_request.user_agent.to_s + rack_request.remote_ip.to_s) if rack_request.remote_ip.present?
+        DfE::Analytics.pseudonymise(rack_request.user_agent.to_s + rack_request.remote_ip.to_s) if rack_request.remote_ip.present?
       end
 
       def ensure_utf8(str)
@@ -133,7 +133,7 @@ module DfE
 
       def user_identifier_for(user)
         user_id = DfE::Analytics.user_identifier(user)
-        user_id = DfE::Analytics.anonymise(user_id) if user_id.present? && DfE::Analytics.config.anonymise_web_request_user_id
+        user_id = DfE::Analytics.pseudonymise(user_id) if user_id.present? && DfE::Analytics.config.pseudonymise_web_request_user_id
 
         user_id
       end

--- a/lib/dfe/analytics/event.rb
+++ b/lib/dfe/analytics/event.rb
@@ -11,7 +11,7 @@ module DfE
         update_entity
         delete_entity
         import_entity
-        analytics_initialise
+        initialise_analytics
       ].freeze
 
       def initialize

--- a/lib/dfe/analytics/event.rb
+++ b/lib/dfe/analytics/event.rb
@@ -5,7 +5,14 @@ require 'active_support/values/time_zone'
 module DfE
   module Analytics
     class Event
-      EVENT_TYPES = %w[web_request create_entity update_entity delete_entity import_entity].freeze
+      EVENT_TYPES = %w[
+        web_request
+        create_entity
+        update_entity
+        delete_entity
+        import_entity
+        analytics_initialise
+      ].freeze
 
       def initialize
         time_zone = 'London'
@@ -24,9 +31,7 @@ module DfE
         allowed_types = EVENT_TYPES + DfE::Analytics.custom_events
         raise 'Invalid analytics event type' unless allowed_types.include?(type.to_s)
 
-        @event_hash.merge!(
-          event_type: type
-        )
+        @event_hash.merge!(event_type: type)
 
         self
       end

--- a/lib/dfe/analytics/initialise.rb
+++ b/lib/dfe/analytics/initialise.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module DfE
+  module Analytics
+    # Send event on dfe analytics startup during initialisation
+    # - Event contains the dfe analytics version, config and other items
+    class Initialise
+      def self.trigger_initialise_event
+        new.send_initialise_event
+      end
+
+      def send_initialise_event
+        return unless DfE::Analytics.enabled?
+
+        initialise_event = DfE::Analytics::Event.new
+                                              .with_type('analytics_initialise')
+                                              .with_data(initialise_data)
+
+        DfE::Analytics::SendEvents.do([initialise_event.as_json])
+      end
+
+      private
+
+      def initialise_data
+        {
+          analytics_version: DfE::Analytics::VERSION,
+          config: {
+            anonymise_web_request_user_id: DfE::Analytics.config.anonymise_web_request_user_id
+          }
+        }
+      end
+    end
+  end
+end

--- a/lib/dfe/analytics/initialise.rb
+++ b/lib/dfe/analytics/initialise.rb
@@ -25,7 +25,7 @@ module DfE
         {
           analytics_version: DfE::Analytics::VERSION,
           config: {
-            anonymise_web_request_user_id: DfE::Analytics.config.anonymise_web_request_user_id
+            pseudonymise_web_request_user_id: DfE::Analytics.config.pseudonymise_web_request_user_id
           }
         }
       end

--- a/lib/dfe/analytics/initialise.rb
+++ b/lib/dfe/analytics/initialise.rb
@@ -13,15 +13,15 @@ module DfE
         return unless DfE::Analytics.enabled?
 
         initialise_event = DfE::Analytics::Event.new
-                                              .with_type('analytics_initialise')
-                                              .with_data(initialise_data)
+                                              .with_type('initialise_analytics')
+                                              .with_data(initialisation_data)
 
         DfE::Analytics::SendEvents.do([initialise_event.as_json])
       end
 
       private
 
-      def initialise_data
+      def initialisation_data
         {
           analytics_version: DfE::Analytics::VERSION,
           config: {

--- a/lib/dfe/analytics/initialise.rb
+++ b/lib/dfe/analytics/initialise.rb
@@ -2,21 +2,41 @@
 
 module DfE
   module Analytics
-    # Send event on dfe analytics startup during initialisation
+    # DfE Analytics initialisation event
+    # - Event should only be sent once, but NOT on startup as this causes errors on some services
     # - Event contains the dfe analytics version, config and other items
     class Initialise
+      # Disable rubocop class variable warnings for class - class variable required to control sending of event
+      # rubocop:disable Style:ClassVars
+      @@initialise_event_sent = false # rubocop:disable Style:ClassVars
+
       def self.trigger_initialise_event
         new.send_initialise_event
+      end
+
+      def self.initialise_event_sent?
+        @@initialise_event_sent
+      end
+
+      def self.initialise_event_sent=(value)
+        @@initialise_event_sent = value # rubocop:disable Style:ClassVars
       end
 
       def send_initialise_event
         return unless DfE::Analytics.enabled?
 
         initialise_event = DfE::Analytics::Event.new
-                                              .with_type('initialise_analytics')
-                                              .with_data(initialisation_data)
+                                                .with_type('initialise_analytics')
+                                                .with_data(initialisation_data)
+                                                .as_json
 
-        DfE::Analytics::SendEvents.do([initialise_event.as_json])
+        if DfE::Analytics.async?
+          DfE::Analytics::SendEvents.perform_later([initialise_event])
+        else
+          DfE::Analytics::SendEvents.perform_now([initialise_event])
+        end
+
+        @@initialise_event_sent = true # rubocop:disable Style:ClassVars
       end
 
       private
@@ -29,6 +49,7 @@ module DfE
           }
         }
       end
+      # rubocop:enable Style:ClassVars
     end
   end
 end

--- a/lib/dfe/analytics/send_events.rb
+++ b/lib/dfe/analytics/send_events.rb
@@ -4,6 +4,9 @@ module DfE
   module Analytics
     class SendEvents < AnalyticsJob
       def self.do(events)
+        # The initialise event is a one-off event that must be sent to BigQuery once only
+        DfE::Analytics::Initialise.trigger_initialise_event unless DfE::Analytics::Initialise.initialise_event_sent?
+
         events = events.map { |event| event.is_a?(Event) ? event.as_json : event }
 
         if DfE::Analytics.async?

--- a/spec/dfe/analytics/entities_spec.rb
+++ b/spec/dfe/analytics/entities_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe DfE::Analytics::Entities do
       it 'sends events that are valid according to the schema' do
         Candidate.create
 
-        expect(DfE::Analytics::SendEvents).to have_received(:perform_later) do |payload|
+        expect(DfE::Analytics::SendEvents).to have_received(:perform_later).twice do |payload|
           schema = DfE::Analytics::EventSchema.new.as_json
           schema_validator = JSONSchemaValidator.new(schema, payload.first)
 
@@ -162,7 +162,7 @@ RSpec.describe DfE::Analytics::Entities do
         entity = Candidate.create
         entity.update(email_address: 'bar@baz.com')
 
-        expect(DfE::Analytics::SendEvents).to have_received(:perform_later).twice do |payload|
+        expect(DfE::Analytics::SendEvents).to have_received(:perform_later).thrice do |payload|
           schema = DfE::Analytics::EventSchema.new.as_json
           schema_validator = JSONSchemaValidator.new(schema, payload.first)
 

--- a/spec/dfe/analytics/entities_spec.rb
+++ b/spec/dfe/analytics/entities_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe DfE::Analytics::Entities do
       it 'sends events that are valid according to the schema' do
         Candidate.create
 
-        expect(DfE::Analytics::SendEvents).to have_received(:perform_later).twice do |payload|
+        expect(DfE::Analytics::SendEvents).to have_received(:perform_later).once do |payload|
           schema = DfE::Analytics::EventSchema.new.as_json
           schema_validator = JSONSchemaValidator.new(schema, payload.first)
 
@@ -162,7 +162,7 @@ RSpec.describe DfE::Analytics::Entities do
         entity = Candidate.create
         entity.update(email_address: 'bar@baz.com')
 
-        expect(DfE::Analytics::SendEvents).to have_received(:perform_later).thrice do |payload|
+        expect(DfE::Analytics::SendEvents).to have_received(:perform_later).twice do |payload|
           schema = DfE::Analytics::EventSchema.new.as_json
           schema_validator = JSONSchemaValidator.new(schema, payload.first)
 

--- a/spec/dfe/analytics/event_spec.rb
+++ b/spec/dfe/analytics/event_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe DfE::Analytics::Event do
   describe 'with_user' do
     let(:regular_user_class) { Struct.new(:id) }
 
-    it 'uses user.id by default without anonymisation' do
+    it 'uses user.id by default without pseudonymisation' do
       event = described_class.new
       id = rand(1000)
       output = event.with_user(regular_user_class.new(id)).as_json
@@ -148,18 +148,18 @@ RSpec.describe DfE::Analytics::Event do
       end
     end
 
-    context 'anonymisation of user_id' do
+    context 'pseudonymisation of user_id' do
       before do
-        allow(DfE::Analytics.config).to receive(:anonymise_web_request_user_id).and_return(true)
+        allow(DfE::Analytics.config).to receive(:pseudonymise_web_request_user_id).and_return(true)
       end
 
-      it 'anonymises the user id' do
+      it 'pseudonymises the user id' do
         event = described_class.new
         uuid = SecureRandom.uuid
-        anonymised_uuid = Digest::SHA2.hexdigest(uuid)
+        pseudonymised_uuid = Digest::SHA2.hexdigest(uuid)
         output = event.with_user(regular_user_class.new(uuid)).as_json
 
-        expect(output['user_id']).to eq anonymised_uuid
+        expect(output['user_id']).to eq pseudonymised_uuid
       end
     end
   end

--- a/spec/dfe/analytics/initialise_spec.rb
+++ b/spec/dfe/analytics/initialise_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe DfE::Analytics::Initialise do
 
       expect(DfE::Analytics::SendEvents).to have_received(:perform_later)
         .with([a_hash_including({
-          'event_type' => 'analytics_initialise',
+          'event_type' => 'initialise_analytics',
           'data' => [
             { 'key' => 'analytics_version', 'value' => [DfE::Analytics::VERSION] },
             { 'key' => 'config',

--- a/spec/dfe/analytics/initialise_spec.rb
+++ b/spec/dfe/analytics/initialise_spec.rb
@@ -21,4 +21,11 @@ RSpec.describe DfE::Analytics::Initialise do
         })])
     end
   end
+
+  describe '.initialise_event_sent=' do
+    it 'allows setting of the class variable' do
+      described_class.initialise_event_sent = true
+      expect(described_class.initialise_event_sent?).to eq(true)
+    end
+  end
 end

--- a/spec/dfe/analytics/initialise_spec.rb
+++ b/spec/dfe/analytics/initialise_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe DfE::Analytics::Initialise do
           'data' => [
             { 'key' => 'analytics_version', 'value' => [DfE::Analytics::VERSION] },
             { 'key' => 'config',
-              'value' => ['{"anonymise_web_request_user_id":false}'] }
+              'value' => ['{"pseudonymise_web_request_user_id":false}'] }
           ]
         })])
     end

--- a/spec/dfe/analytics/initialise_spec.rb
+++ b/spec/dfe/analytics/initialise_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe DfE::Analytics::Initialise do
+  before do
+    allow(DfE::Analytics::SendEvents).to receive(:perform_later)
+    allow(DfE::Analytics).to receive(:enabled?).and_return(true)
+  end
+
+  describe 'trigger_initialise_event ' do
+    it 'includes the expected attributes' do
+      described_class.trigger_initialise_event
+
+      expect(DfE::Analytics::SendEvents).to have_received(:perform_later)
+        .with([a_hash_including({
+          'event_type' => 'analytics_initialise',
+          'data' => [
+            { 'key' => 'analytics_version', 'value' => [DfE::Analytics::VERSION] },
+            { 'key' => 'config',
+              'value' => ['{"anonymise_web_request_user_id":false}'] }
+          ]
+        })])
+    end
+  end
+end

--- a/spec/dfe/analytics_spec.rb
+++ b/spec/dfe/analytics_spec.rb
@@ -5,6 +5,14 @@ RSpec.describe DfE::Analytics do
     expect(DfE::Analytics::VERSION).not_to be nil
   end
 
+  it 'supports the pseudonymise method' do
+    expect(DfE::Analytics.pseudonymise('foo_bar')).to eq('4928cae8b37b3d1113f5e01e60c967df6c2b9e826dc7d91488d23a62fec715ba')
+  end
+
+  it 'supports the anonymise method for backwards compatibility' do
+    expect(DfE::Analytics.anonymise('foo_bar')).to eq('4928cae8b37b3d1113f5e01e60c967df6c2b9e826dc7d91488d23a62fec715ba')
+  end
+
   it 'has documentation entries for all the config options' do
     config_options = DfE::Analytics.config.members
 

--- a/spec/dfe/analytics_spec.rb
+++ b/spec/dfe/analytics_spec.rb
@@ -184,12 +184,4 @@ RSpec.describe DfE::Analytics do
       end
     end
   end
-
-  it 'triggers the initialisation event' do
-    allow(DfE::Analytics::Initialise).to receive(:trigger_initialise_event)
-
-    DfE::Analytics.initialize!
-
-    expect(DfE::Analytics::Initialise).to have_received(:trigger_initialise_event)
-  end
 end

--- a/spec/dfe/analytics_spec.rb
+++ b/spec/dfe/analytics_spec.rb
@@ -176,4 +176,12 @@ RSpec.describe DfE::Analytics do
       end
     end
   end
+
+  it 'triggers the initialisation event' do
+     allow(DfE::Analytics::Initialise).to receive(:trigger_initialise_event)
+
+     DfE::Analytics.initialize!
+
+     expect(DfE::Analytics::Initialise).to have_received(:trigger_initialise_event)
+  end
 end

--- a/spec/dfe/analytics_spec.rb
+++ b/spec/dfe/analytics_spec.rb
@@ -178,10 +178,10 @@ RSpec.describe DfE::Analytics do
   end
 
   it 'triggers the initialisation event' do
-     allow(DfE::Analytics::Initialise).to receive(:trigger_initialise_event)
+    allow(DfE::Analytics::Initialise).to receive(:trigger_initialise_event)
 
-     DfE::Analytics.initialize!
+    DfE::Analytics.initialize!
 
-     expect(DfE::Analytics::Initialise).to have_received(:trigger_initialise_event)
+    expect(DfE::Analytics::Initialise).to have_received(:trigger_initialise_event)
   end
 end

--- a/spec/requests/analytics_spec.rb
+++ b/spec/requests/analytics_spec.rb
@@ -55,39 +55,102 @@ RSpec.describe 'Analytics flow', type: :request do
     Rails.application.routes_reloader.reload!
   end
 
-  it 'works end-to-end' do
-    request_event = { environment: 'test',
-                      event_type: 'web_request',
-                      request_method: 'POST',
-                      request_path: '/example/create' }
-    request_event_post = stub_analytics_event_submission.with(body: /web_request/)
+  describe 'end-to-end API calls' do
+    let!(:initialise_event_post) { stub_analytics_event_submission.with(body: /initialise_analytics/) }
+    let!(:request_event_post) { stub_analytics_event_submission.with(body: /request_path/) }
+    let!(:model_event_post) { stub_analytics_event_submission.with(body: /create_entity/) }
 
-    model_event = { environment: 'test',
-                    event_type: 'create_entity',
-                    entity_table_name: Candidate.table_name }
-    model_event_post = stub_analytics_event_submission.with(body: /create_entity/)
-
-    perform_enqueued_jobs do
-      post '/example/create'
+    let(:initialise_event) do
+      {
+        environment: 'test',
+        event_type: 'initialise_analytics'
+      }
     end
 
-    request_uuid = nil # we'll compare this across requests
+    let(:request_event) do
+      {
+        environment: 'test',
+        event_type: 'web_request',
+        request_method: 'POST',
+        request_path: '/example/create'
+      }
+    end
 
-    expect(request_event_post.with do |req|
-      body = JSON.parse(req.body)
-      payload = body['rows'].first['json']
-      expect(payload.except('occurred_at', 'request_uuid')).to match(a_hash_including(request_event.stringify_keys))
+    let(:model_event) do
+      {
+        environment: 'test',
+        event_type: 'create_entity',
+        entity_table_name: Candidate.table_name
+      }
+    end
 
-      request_uuid = payload['request_uuid']
-    end).to have_been_made
+    before do
+      DfE::Analytics::Initialise.initialise_event_sent = initialise_event_sent
 
-    expect(model_event_post.with do |req|
-      body = JSON.parse(req.body)
-      payload = body['rows'].first['json']
-      expect(payload.except('occurred_at', 'request_uuid')).to match(a_hash_including(model_event.stringify_keys))
+      perform_enqueued_jobs do
+        post '/example/create'
+      end
+    end
 
-      expect(payload['request_uuid']).to eq(request_uuid)
-    end).to have_been_made
+    context 'when initialise_analytics event NOT already sent' do
+      let(:initialise_event_sent) { false }
+
+      it 'calls the expected BigQuery APIs' do
+        request_uuid = nil # we'll compare this across requests
+
+        expect(initialise_event_post.with do |req|
+          body = JSON.parse(req.body)
+          payload = body['rows'].first['json']
+          expect(payload.except('occurred_at')).to match(a_hash_including(initialise_event.stringify_keys))
+        end).to have_been_made
+
+        expect(request_event_post.with do |req|
+          body = JSON.parse(req.body)
+          payload = body['rows'].first['json']
+          expect(payload.except('occurred_at', 'request_uuid')).to match(a_hash_including(request_event.stringify_keys))
+
+          request_uuid = payload['request_uuid']
+        end).to have_been_made
+
+        expect(model_event_post.with do |req|
+          body = JSON.parse(req.body)
+          payload = body['rows'].first['json']
+          expect(payload.except('occurred_at', 'request_uuid')).to match(a_hash_including(model_event.stringify_keys))
+
+          expect(payload['request_uuid']).to eq(request_uuid)
+        end).to have_been_made
+      end
+    end
+
+    context 'when initialise_analytics event already sent' do
+      let(:initialise_event_sent) { true }
+
+      it 'calls the expected BigQuery APIs' do
+        request_uuid = nil # we'll compare this across requests
+
+        expect(initialise_event_post.with do |req|
+          body = JSON.parse(req.body)
+          payload = body['rows'].first['json']
+          expect(payload.except('occurred_at')).to match(a_hash_including(initialise_event.stringify_keys))
+        end).to_not have_been_made
+
+        expect(request_event_post.with do |req|
+          body = JSON.parse(req.body)
+          payload = body['rows'].first['json']
+          expect(payload.except('occurred_at', 'request_uuid')).to match(a_hash_including(request_event.stringify_keys))
+
+          request_uuid = payload['request_uuid']
+        end).to have_been_made
+
+        expect(model_event_post.with do |req|
+          body = JSON.parse(req.body)
+          payload = body['rows'].first['json']
+          expect(payload.except('occurred_at', 'request_uuid')).to match(a_hash_including(model_event.stringify_keys))
+
+          expect(payload['request_uuid']).to eq(request_uuid)
+        end).to have_been_made
+      end
+    end
   end
 
   context 'when a queue is specified' do

--- a/spec/requests/analytics_spec.rb
+++ b/spec/requests/analytics_spec.rb
@@ -128,11 +128,7 @@ RSpec.describe 'Analytics flow', type: :request do
       it 'calls the expected BigQuery APIs' do
         request_uuid = nil # we'll compare this across requests
 
-        expect(initialise_event_post.with do |req|
-          body = JSON.parse(req.body)
-          payload = body['rows'].first['json']
-          expect(payload.except('occurred_at')).to match(a_hash_including(initialise_event.stringify_keys))
-        end).to_not have_been_made
+        expect(initialise_event_post).to_not have_been_made
 
         expect(request_event_post.with do |req|
           body = JSON.parse(req.body)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,7 @@ RSpec.configure do |config|
 
   config.around do |example|
     ActiveRecord::Base.connection.migration_context.migrate
+    DfE::Analytics::Initialise.initialise_event_sent = true
     example.run
   end
 


### PR DESCRIPTION
[Trello-1168](https://trello.com/c/KKNNGzR9/1168-dfe-analytics-gem-send-system-config-event)

Send dfe analytics version and required config items from DfE Analytics to BigQuery as an "analytics_initialise" event.

The "analytics_initialise" is a one-off on startup event.

Also, some miscellaneous READ.me updates:

- Document the anonymise data method available
- A further information and instructions on pushing tags

