### PR TITLE
Support single table inheritance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
     backport (1.2.0)
     benchmark (0.2.0)
     builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     console (1.15.3)
       fiber-local
@@ -231,6 +232,9 @@ GEM
     protocol-http2 (0.14.2)
       protocol-hpack (~> 1.4)
       protocol-http (~> 0.18)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (4.0.6)
     racc (1.6.0)
     rack (2.2.3)
@@ -370,6 +374,7 @@ DEPENDENCIES
   gem-release
   github_changelog_generator
   json-schema (~> 2.8)
+  pry (~> 0)
   rails (>= 6)
   rspec-rails (~> 5.0)
   rubocop (~> 1.26)

--- a/dfe-analytics.gemspec
+++ b/dfe-analytics.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'gem-release', '~> 2.2'
   spec.add_development_dependency 'github_changelog_generator', '~> 1.16'
   spec.add_development_dependency 'json-schema', '~> 2.8'
+  spec.add_development_dependency 'pry', '~> 0'
   spec.add_development_dependency 'rails', '>= 6'
   spec.add_development_dependency 'rspec-rails', '~> 5.0'
   spec.add_development_dependency 'rubocop', '~> 1.26'

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -96,11 +96,12 @@ module DfE
       DfE::Analytics::Fields.check!
 
       entities_for_analytics.each do |entity|
-        model = model_for_entity(entity)
-        if model.include?(DfE::Analytics::Entities) && !@shown_deprecation_warning
-          Rails.logger.info("DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (#{model.name}), but it's included automatically since v1.4. You're running v#{DfE::Analytics::VERSION}. To silence this warning, remove the include from model definitions in app/models.")
-        else
-          model.include(DfE::Analytics::Entities)
+        models_for_entity(entity).each do |m|
+          if m.include?(DfE::Analytics::Entities) && !@shown_deprecation_warning
+            Rails.logger.info("DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (#{m.name}), but it's included automatically since v1.4. You're running v#{DfE::Analytics::VERSION}. To silence this warning, remove the include from model definitions in app/models.")
+          else
+            m.include(DfE::Analytics::Entities)
+          end
         end
       end
     rescue ActiveRecord::PendingMigrationError
@@ -161,7 +162,7 @@ module DfE
       entity_model_mapping.keys.map(&:to_sym)
     end
 
-    def self.model_for_entity(entity)
+    def self.models_for_entity(entity)
       entity_model_mapping.fetch(entity.to_s)
     end
 
@@ -208,7 +209,7 @@ module DfE
 
         ActiveRecord::Base.descendants
           .reject(&:abstract_class?)
-          .index_by(&:table_name)
+          .group_by(&:table_name)
           .except(*rails_tables)
       end
     end

--- a/lib/dfe/analytics/fields.rb
+++ b/lib/dfe/analytics/fields.rb
@@ -61,7 +61,7 @@ module DfE
       def self.database
         DfE::Analytics.all_entities_in_application
           .reduce({}) do |list, entity|
-            attrs = DfE::Analytics.model_for_entity(entity).attribute_names
+            attrs = DfE::Analytics.models_for_entity(entity).flat_map(&:attribute_names)
             list[entity] = attrs
 
             list

--- a/lib/dfe/analytics/load_entities.rb
+++ b/lib/dfe/analytics/load_entities.rb
@@ -11,29 +11,29 @@ module DfE
       end
 
       def run
-        model = DfE::Analytics.model_for_entity(@entity_name)
+        DfE::Analytics.models_for_entity(@entity_name).map do |model|
+          unless model.any?
+            Rails.logger.info("No entities to process for #{@entity_name}")
+            next
+          end
 
-        unless model.any?
-          Rails.logger.info("No entities to process for #{@entity_name}")
-          return
+          unless model.primary_key.to_sym == :id
+            Rails.logger.info("Not processing #{@entity_name} as we do not support non-id primary keys")
+            next
+          end
+
+          Rails.logger.info("Processing data for #{@entity_name} with row count #{model.count}")
+
+          batch_count = 0
+
+          model.in_batches(of: BQ_BATCH_ROWS) do |relation|
+            batch_count += 1
+            ids = relation.pluck(:id)
+            DfE::Analytics::LoadEntityBatch.perform_later(model.to_s, ids)
+          end
+
+          Rails.logger.info "Enqueued #{batch_count} batches of #{BQ_BATCH_ROWS} #{@entity_name} records for importing to BigQuery"
         end
-
-        unless model.primary_key.to_sym == :id
-          Rails.logger.info("Not processing #{@entity_name} as we do not support non-id primary keys")
-          return
-        end
-
-        Rails.logger.info("Processing data for #{@entity_name} with row count #{model.count}")
-
-        batch_count = 0
-
-        model.in_batches(of: BQ_BATCH_ROWS) do |relation|
-          batch_count += 1
-          ids = relation.pluck(:id)
-          DfE::Analytics::LoadEntityBatch.perform_later(model.to_s, ids)
-        end
-
-        Rails.logger.info "Enqueued #{batch_count} batches of #{BQ_BATCH_ROWS} #{@entity_name} records for importing to BigQuery"
       end
     end
   end

--- a/spec/dfe/analytics/single_table_inheritance_spec.rb
+++ b/spec/dfe/analytics/single_table_inheritance_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Inclusion in the context of single table inheritance' do
+  with_model :Parent do
+    table do |t|
+      t.string :type
+    end
+  end
+
+  before do
+    allow(DfE::Analytics).to receive(:enabled?).and_return(true)
+    allow(DfE::Analytics).to receive(:allowlist).and_return({ Parent.table_name.to_sym => %w[type] })
+
+    stub_const('Child', Class.new(Parent))
+    stub_const('Sibling', Class.new(Parent))
+
+    # autogenerate a compliant blocklist
+    allow(DfE::Analytics).to receive(:blocklist).and_return(DfE::Analytics::Fields.generate_blocklist)
+    DfE::Analytics.initialize!
+  end
+
+  it 'correctly includes callbacks for each member of the STI party' do
+    expect(Parent).to include(DfE::Analytics::Entities)
+    expect(Child).to include(DfE::Analytics::Entities)
+    expect(Sibling).to include(DfE::Analytics::Entities)
+  end
+end


### PR DESCRIPTION
When apps use single-table inheritance, multiple Rails models share the same database table - i.e. they are considered a single 'entity' by DfE Analytics.

This isn't good, because it means that at most one model can be associated with a single table. In turn this means that we will not know to attach callbacks to the other models in the STI heirarchy. In practice, due to the order in which `ActiveRecord::Base.descendants` returns the models, this ends up being the alphabetically first child — not the parent, and not any of the siblings.

~Added DNM so @JR-G can test it out on Apply first!~

Confirmed working on Apply