### PR TITLE
Add better error logging when calling BigQuery insert API on error

### DIFF
--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -70,10 +70,10 @@ module DfE
       yield(config)
 
       config.enable_analytics                 ||= proc { true }
-      config.bigquery_table_name              ||= ENV['BIGQUERY_TABLE_NAME']
-      config.bigquery_project_id              ||= ENV['BIGQUERY_PROJECT_ID']
-      config.bigquery_dataset                 ||= ENV['BIGQUERY_DATASET']
-      config.bigquery_api_json_key            ||= ENV['BIGQUERY_API_JSON_KEY']
+      config.bigquery_table_name              ||= ENV.fetch('BIGQUERY_TABLE_NAME', nil)
+      config.bigquery_project_id              ||= ENV.fetch('BIGQUERY_PROJECT_ID', nil)
+      config.bigquery_dataset                 ||= ENV.fetch('BIGQUERY_DATASET', nil)
+      config.bigquery_api_json_key            ||= ENV.fetch('BIGQUERY_API_JSON_KEY', nil)
       config.bigquery_retries                 ||= 3
       config.bigquery_timeout                 ||= 120
       config.environment                      ||= ENV.fetch('RAILS_ENV', 'development')

--- a/spec/dfe/analytics/send_events_spec.rb
+++ b/spec/dfe/analytics/send_events_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe DfE::Analytics::SendEvents do
       end
 
       it 'logs the error message' do
-        expect(Rails.logger).to receive(:error).with(/Could not insert all events:/)
+        expect(Rails.logger).to receive(:error).with(/Could not insert 1 event\(s\):/)
 
         perform
       rescue DfE::Analytics::SendEventsError


### PR DESCRIPTION
Currently when doing a full import on the Teaching Vacancies App, calls to the BigQuery insert API are failing.

There are very few clues in the error logs as to which events are causing the failures. As the full import calls the BigQuery insert API in batches of 500, it's also very difficult to pinpoint the event causing the failure.

This PR adds better error logging when calling the API and logs the events causing the failures also.