### PR TITLE
v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,26 @@
 # Changelog
 
-## [v1.9.0](https://github.com/DFE-Digital/dfe-analytics/tree/v1.9.0) (2023-05-31)
+## [v1.10.0](https://github.com/DFE-Digital/dfe-analytics/tree/v1.10.0) (2023-06-29)
 
-[Full Changelog](https://github.com/DFE-Digital/dfe-analytics/compare/v1.8.1...v1.9.0)
+[Full Changelog](https://github.com/DFE-Digital/dfe-analytics/compare/v1.9.0...v1.10.0)
 
 **Merged pull requests:**
 
+- Add better error logging when calling BigQuery insert API on error [\#78](https://github.com/DFE-Digital/dfe-analytics/pull/78) ([asatwal](https://github.com/asatwal))
+- Support single table inheritance [\#77](https://github.com/DFE-Digital/dfe-analytics/pull/77) ([duncanjbrown](https://github.com/duncanjbrown))
 - Send config events [\#75](https://github.com/DFE-Digital/dfe-analytics/pull/75) ([asatwal](https://github.com/asatwal))
+- Minor wording fixes [\#74](https://github.com/DFE-Digital/dfe-analytics/pull/74) ([scruti](https://github.com/scruti))
+- Upgrade Nokogiri Gem to v1.14 [\#73](https://github.com/DFE-Digital/dfe-analytics/pull/73) ([scruti](https://github.com/scruti))
 - Refer serious misconduct / Apply for QTS unable to upgrade to DfE Analytics GEM \(v1.8.0\) [\#70](https://github.com/DFE-Digital/dfe-analytics/pull/70) ([asatwal](https://github.com/asatwal))
+- Add event details to send event error log message [\#69](https://github.com/DFE-Digital/dfe-analytics/pull/69) ([asatwal](https://github.com/asatwal))
 - Send request events for cached pages with rack middleware [\#67](https://github.com/DFE-Digital/dfe-analytics/pull/67) ([asatwal](https://github.com/asatwal))
 - Update advice on queue config and running imports [\#65](https://github.com/DFE-Digital/dfe-analytics/pull/65) ([asatwal](https://github.com/asatwal))
 - Add anonymisation of user\_id in the web request event data [\#64](https://github.com/DFE-Digital/dfe-analytics/pull/64) ([asatwal](https://github.com/asatwal))
 - Log Matched Events [\#63](https://github.com/DFE-Digital/dfe-analytics/pull/63) ([asatwal](https://github.com/asatwal))
+
+## [v1.9.0](https://github.com/DFE-Digital/dfe-analytics/tree/v1.9.0) (2023-05-31)
+
+[Full Changelog](https://github.com/DFE-Digital/dfe-analytics/compare/v1.8.1...v1.9.0)
 
 ## [v1.8.1](https://github.com/DFE-Digital/dfe-analytics/tree/v1.8.1) (2023-04-27)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dfe-analytics (1.9.0)
+    dfe-analytics (1.10.0)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 

--- a/lib/dfe/analytics/version.rb
+++ b/lib/dfe/analytics/version.rb
@@ -2,6 +2,6 @@
 
 module DfE
   module Analytics
-    VERSION = '1.9.0'
+    VERSION = '1.10.0'
   end
 end


### PR DESCRIPTION
Production release containing the following:

- Add better error logging when calling BigQuery insert API on error 
- Support single table inheritance
- Minor wording fixes
- Upgrade Nokogiri Gem to v1.14 
- Minor README.md updates 
