### PR TITLE
Do not attempt initialization when the user is changing the database

### DIFF
--- a/lib/dfe/analytics/railtie.rb
+++ b/lib/dfe/analytics/railtie.rb
@@ -34,7 +34,15 @@ module DfE
       config.after_initialize do
         # internal gem tests will sometimes suppress this so they can test the
         # init process
-        DfE::Analytics.initialize! unless ENV['SUPPRESS_DFE_ANALYTICS_INIT']
+        if running_db_rake_task? || ENV['SUPPRESS_DFE_ANALYTICS_INIT']
+          puts 'Skipping DfE::Analytics initialization'
+        else
+          DfE::Analytics.initialize!
+        end
+      end
+
+      def running_db_rake_task?
+        defined?(Rake) && Rake.application.top_level_tasks.any? { |t| t.start_with?('db:') }
       end
 
       rake_tasks do


### PR DESCRIPTION
db:* rake commands are often useful to bring the database into line with what DfE::Analytics expects, so it can be painful not to be able to run them when the config is inconsistent. Allow these commands at all times - full checks will run on app or test boot anyway.

I couldn't think of a reasonable way to test this!