### PR TITLE
Fix single table inheritance deprecation warning bug

### DIFF
--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -98,10 +98,11 @@ module DfE
 
       entities_for_analytics.each do |entity|
         models_for_entity(entity).each do |m|
-          if m.include?(DfE::Analytics::Entities) && !@shown_deprecation_warning
+          if m.include?(DfE::Analytics::Entities)
             Rails.logger.info("DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (#{m.name}), but it's included automatically since v1.4. You're running v#{DfE::Analytics::VERSION}. To silence this warning, remove the include from model definitions in app/models.")
           else
             m.include(DfE::Analytics::Entities)
+            break
           end
         end
       end

--- a/spec/dfe/analytics/single_table_inheritance_spec.rb
+++ b/spec/dfe/analytics/single_table_inheritance_spec.rb
@@ -16,12 +16,17 @@ RSpec.describe 'Inclusion in the context of single table inheritance' do
 
     # autogenerate a compliant blocklist
     allow(DfE::Analytics).to receive(:blocklist).and_return(DfE::Analytics::Fields.generate_blocklist)
-    DfE::Analytics.initialize!
   end
 
   it 'correctly includes callbacks for each member of the STI party' do
+    DfE::Analytics.initialize!
     expect(Parent).to include(DfE::Analytics::Entities)
     expect(Child).to include(DfE::Analytics::Entities)
     expect(Sibling).to include(DfE::Analytics::Entities)
+  end
+
+  it 'does not log a deprecation warning' do
+    expect(Rails.logger).not_to receive(:info).with(/DEPRECATION WARNING/)
+    DfE::Analytics.initialize!
   end
 end


### PR DESCRIPTION
This fix prevents the deprecation warning `Entities was manually included in a model` from being raised when using single table inheritance. The warning was being raised because the `DfE::Analytics::Entities` module gets included in all the entity model classes.

I noticed we were still getting deprecation warnings after this PR got merged: https://github.com/DFE-Digital/apply-for-teacher-training/pull/8374

```shell
DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (ApplicationWorkExperience), but it's included automatically since v1.4. You're running v1.10.1. To silence this warning, remove the include from model definitions in app/models.
DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (ApplicationVolunteeringExperience), but it's included automatically since v1.4. You're running v1.10.1. To silence this warning, remove the include from model definitions in app/models.
DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (TextCondition), but it's included automatically since v1.4. You're running v1.10.1. To silence this warning, remove the include from model definitions in app/models.
DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (SkeCondition), but it's included automatically since v1.4. You're running v1.10.1. To silence this warning, remove the include from model definitions in app/models.
DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (ReferenceCondition), but it's included automatically since v1.4. You're running v1.10.1. To silence this warning, remove the include from model definitions in app/models.
```

Looking into the code it seems that once the first include runs, all the following classes in that group already have the model included. I initially thought that it gets included in the parent class, but that doesn't seem to be the case.

```shell
> mfes = models_for_entity(entity)

> mfes[0].include?(DfE::Analytics::Entities)
=> false
> mfes[1].include?(DfE::Analytics::Entities)
=> false
> mfes[2].include?(DfE::Analytics::Entities)
=> false

> mfes[0].include(DfE::Analytics::Entities)

> mfes[0].include?(DfE::Analytics::Entities)
=> true
> mfes[1].include?(DfE::Analytics::Entities)
=> true
> mfes[2].include?(DfE::Analytics::Entities)
=> true

> mfes[0].superclass
=> ApplicationRecord(abstract)

> mfes[0].superclass.include?(DfE::Analytics::Entities)
=> false
```

I also removed the `@shown_deprecation_warning` instance variable as it wasn't serving any purpose.

Tagging @duncanjbrown @JR-G here as I don't have access to this repo