### PR TITLE
Prevent duplicate fields in blocklist when using STI

### DIFF
--- a/lib/dfe/analytics/fields.rb
+++ b/lib/dfe/analytics/fields.rb
@@ -61,7 +61,7 @@ module DfE
       def self.database
         DfE::Analytics.all_entities_in_application
           .reduce({}) do |list, entity|
-            attrs = DfE::Analytics.models_for_entity(entity).flat_map(&:attribute_names)
+            attrs = DfE::Analytics.models_for_entity(entity).flat_map(&:attribute_names).uniq
             list[entity] = attrs
 
             list

--- a/spec/dfe/analytics/fields_spec.rb
+++ b/spec/dfe/analytics/fields_spec.rb
@@ -80,6 +80,12 @@ RSpec.describe DfE::Analytics::Fields do
         expect(fields).to include('id')
         expect(fields).not_to include('email_address')
       end
+
+      it 'does not include duplicate fields when the model uses single table inheritance' do
+        stub_const('Child', Class.new(Candidate))
+        fields = described_class.generate_blocklist[Candidate.table_name.to_sym]
+        expect(fields).to eq(fields.uniq)
+      end
     end
 
     describe '.surplus_fields' do


### PR DESCRIPTION
When the application has models that are configured with single table inheritance the generated blocklist will contain duplicate field names for the table (once for each model).

This is due to the behaviour of `attribute_names` in Rails; it retrieves the names directly from the table columns and doesn't filter based on the context of the subclass.

To avoid this we need to `uniq` the attribute names generated for the blocklist.

Example blocklist prior to change (assuming a parent/child using STI):

```
{:with_model_candidates_43990_9360=>["id", "first_name", "id", "first_name"]}
```

And after change:

```
{:with_model_candidates_43990_9360=>["id", "first_name"]}
```