### PR TITLE
Add log message for entities without primary_key, update README.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,6 @@ Once `analytics.yml` and friends are populated, the associated models will be
 automatically instrumented to send updates to BigQuery via ActiveRecord
 callbacks.
 
-
 ### 5. Send web request events
 
 #### Web requests
@@ -251,6 +250,9 @@ where `entity_name` is the name of the table you wish to import.
 **IMPORTANT**: if you have a lot of records, this will enqueue a lot of jobs.
 Consider not running an
 import when there is a lot of traffic on your service.
+
+An entity will only be loaded if it has a primary key. For some entities, such as join tables,
+it might be necessary to add a primary key to the table and to update the relevant `analytics.yml`, prior to running the import.
 
 ## Custom events
 

--- a/lib/dfe/analytics/load_entities.rb
+++ b/lib/dfe/analytics/load_entities.rb
@@ -17,7 +17,14 @@ module DfE
             next
           end
 
-          unless model.primary_key.to_sym == :id
+          primary_key = model.primary_key
+
+          if primary_key.nil?
+            Rails.logger.info("Not processing #{@entity_name} as it does not have a primary key")
+            next
+          end
+
+          unless primary_key.to_sym == :id
             Rails.logger.info("Not processing #{@entity_name} as we do not support non-id primary keys")
             next
           end

--- a/spec/dfe/analytics/load_entities_spec.rb
+++ b/spec/dfe/analytics/load_entities_spec.rb
@@ -19,6 +19,16 @@ RSpec.describe DfE::Analytics::LoadEntities do
     end
   end
 
+  with_model :ModelWithoutPrimaryKey do
+    table id: false do |t|
+      t.string :custom_key
+    end
+
+    model do |m|
+      m.primary_key = nil
+    end
+  end
+
   before do
     allow(DfE::Analytics).to receive(:allowlist).and_return({
       Candidate.table_name.to_sym => ['email_address']
@@ -77,5 +87,12 @@ RSpec.describe DfE::Analytics::LoadEntities do
 
     expect { described_class.new(entity_name: ModelWithCustomPrimaryKey.table_name).run }.not_to raise_error
     expect(Rails.logger).to have_received(:info).with(/we do not support non-id primary keys/)
+  end
+
+  it 'does not fail with models whose primary key is nil' do
+    ModelWithoutPrimaryKey.create
+
+    expect { described_class.new(entity_name: ModelWithoutPrimaryKey.table_name).run }.not_to raise_error
+    expect(Rails.logger).to have_received(:info).with(/Not processing #{ModelWithoutPrimaryKey.table_name} as it does not have a primary key/)
   end
 end


### PR DESCRIPTION
`dfe-analytics` does not load entities if they do not have a primary key. This issue was discovered when ECF (CPD) were installing the gem and were unable to load a join table which did not have a primary key.

It was decided to update the error messaging / readme to ask that a primary key to be added to the entity in these situations.

This PR includes these additions (1. update to logging message 2. update to README.rb)

Updates to the loading strategy, to make it more robust, will be considered in future.