### PR TITLE
Wait polynomially longer rather than exponentially

### DIFF
--- a/lib/dfe/analytics/analytics_job.rb
+++ b/lib/dfe/analytics/analytics_job.rb
@@ -2,7 +2,7 @@ module DfE
   module Analytics
     class AnalyticsJob < ActiveJob::Base
       queue_as { DfE::Analytics.config.queue }
-      retry_on StandardError, wait: :exponentially_longer, attempts: 5
+      retry_on StandardError, wait: :polynomially_longer, attempts: 5
     end
   end
 end


### PR DESCRIPTION
In Rails 7.1.0 `wait: :exponentially_longer` will actually wait polynomially longer and [has been deprecated](https://github.com/rails/rails/pull/49292).