### PR TITLE
Add publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag
+        required: true
+jobs:
+  publish:
+    name: Publish GitHub Package Registry
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.tag }}
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+
+      - name: Install gems
+        env:
+          RAILS_VERSION: '6.1.7'
+        run: |
+          gem install bundler
+          bundle install --jobs 4 --retry 3
+
+      - name: Publish gem
+        uses: dawidd6/action-publish-gem@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This flow allows tags to be built into gems and those gems published to GitHub's container registry, simplifying the Gemfile entries for projects that consume it.

The Ruby and Rails versions align with the lowest versions in the test matrix.

I didn't add Rubygems publishing because I'm not sure who's account it should be added to, perhaps that could follow.
