### PR TITLE
Update scheduling for Entity Table Check Job

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ which means they can't be joined up.
 
 ### Entity Table Check Job
 
-If you have *Sidekiq* and *Sidekiq-Cron* installed, you might want to enable the *Entity Table Check Job* to verify that the latest version of an entity table in Big Query matches the database. Ideally the job would be scheduled to run every night.
+If you are using a background processing tool or scheduler (such as Sidekiq, Sidekiq-Cron, Resque, Delayed Job or other alternatives), you may want to configure the Entity Table Check Job. This job is designed to ensure the latest version of an entity table in BigQuery is in sync with the database. It is advisable to schedule this job to run on a nightly basis for consistent data verification.
 
 To enable the Entity Table Check Job, update the configuration option in `config/initializers/dfe_analytics.rb`:
 
@@ -332,7 +332,7 @@ To enable the Entity Table Check Job, update the configuration option in `config
 config.entity_table_checks_enabled = true
 ```
 
-Once enabled, you can set up the Sidekiq-Cron job using the following configuration:
+Once enabled, you will need to configure the job according to the syntax and settings of your chosen background processor or scheduler. Below is an example using Sidekiq-Cron, but similar settings apply for other systems like Resque-Scheduler or Delayed Job's recurring jobs:
 
 ```
 entity_table_check_job:

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Once enabled, you can set up the Sidekiq-Cron job using the following configurat
 
 ```
 entity_table_check_job:
-  cron: "0 0 * * *", #Every day at midnight
+  cron: "0 0 * * *", #e.g. every day at midnight
   class: "DfE::Analytics::EntityTableCheckJob",
   queue: default
 ```

--- a/README.md
+++ b/README.md
@@ -324,11 +324,21 @@ which means they can't be joined up.
 
 ### Entity Table Check Job
 
-The entity table check job will run every night and sends data to verify that the latest version of an entity table in BigQuery matches the database. The job is defaulted to false but can be changed by updating the configuration option in
-`config/initializers/dfe_analytics.rb`:
+If you have *Sidekiq* and *Sidekiq-Cron* installed, you might want to enable the *Entity Table Check Job* to verify that the latest version of an entity table in Big Query matches the database. Ideally the job would be scheduled to run every night.
+
+To enable the Entity Table Check Job, update the configuration option in `config/initializers/dfe_analytics.rb`:
 
 ```ruby
 config.entity_table_checks_enabled = true
+```
+
+Once enabled, you can set up the Sidekiq-Cron job using the following configuration:
+
+```
+entity_table_check_job:
+  cron: "0 0 * * *", #Every day at midnight
+  class: "DfE::Analytics::EntityTableCheckJob",
+  queue: default
 ```
 
 ## Testing

--- a/lib/dfe/analytics/entity_table_check_job.rb
+++ b/lib/dfe/analytics/entity_table_check_job.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 require 'active_support/values/time_zone'
+require 'pry'
 
 module DfE
   module Analytics
+    binding.pry
     # Reschedules with sidekiq_cron to run every 24hours
     class EntityTableCheckJob
       include Sidekiq::Worker if defined?(Sidekiq::Worker)

--- a/lib/dfe/analytics/entity_table_check_job.rb
+++ b/lib/dfe/analytics/entity_table_check_job.rb
@@ -5,7 +5,7 @@ require 'active_support/values/time_zone'
 module DfE
   module Analytics
     # Reschedules with sidekiq_cron to run every 24hours
-    class EntityTableCheckJob < AnalyticsJob
+    class EntityTableCheckJob
       include Sidekiq::Worker if defined?(Sidekiq::Worker)
 
       TIME_ZONE = 'London'

--- a/lib/dfe/analytics/entity_table_check_job.rb
+++ b/lib/dfe/analytics/entity_table_check_job.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 require 'active_support/values/time_zone'
-require 'pry'
 
 module DfE
   module Analytics
-    binding.pry
     # Reschedules with sidekiq_cron to run every 24hours
     class EntityTableCheckJob
       include Sidekiq::Worker if defined?(Sidekiq::Worker)
@@ -13,6 +11,8 @@ module DfE
       TIME_ZONE = 'London'
 
       def perform
+        return unless DfE::Analytics.entity_table_checks_enabled?
+
         DfE::Analytics.entities_for_analytics.each do |entity_name|
           DfE::Analytics.models_for_entity(entity_name).each do |model|
             entity_table_check_event = DfE::Analytics::Event.new

--- a/lib/dfe/analytics/entity_table_check_job.rb
+++ b/lib/dfe/analytics/entity_table_check_job.rb
@@ -4,10 +4,8 @@ require 'active_support/values/time_zone'
 
 module DfE
   module Analytics
-    # Reschedules with sidekiq_cron to run every 24hours
-    class EntityTableCheckJob
-      include Sidekiq::Worker if defined?(Sidekiq::Worker)
-
+    # To ensure BigQuery is in sync with the database
+    class EntityTableCheckJob < AnalyticsJob
       TIME_ZONE = 'London'
 
       def perform
@@ -20,7 +18,7 @@ module DfE
                                                             .with_entity_table_name(model.table_name)
                                                             .with_data(entity_table_check_data(model))
                                                             .as_json
-            DfE::Analytics::SendEvents.perform_async([entity_table_check_event])
+            DfE::Analytics::SendEvents.perform_later([entity_table_check_event])
             Rails.logger.info("Processing data for #{model.table_name} with row count #{model.count}")
           end
         end

--- a/lib/dfe/analytics/initialisation_events.rb
+++ b/lib/dfe/analytics/initialisation_events.rb
@@ -36,7 +36,7 @@ module DfE
           DfE::Analytics::SendEvents.perform_now([initialise_analytics_event])
         end
 
-        DfE::Analytics::EntityTableCheckJob.perform_later if DfE::Analytics.entity_table_checks_enabled?
+        DfE::Analytics::EntityTableCheckJob.perform_async if defined?(Sidekiq) && DfE::Analytics.entity_table_checks_enabled?
 
         @@initialisation_events_sent = true # rubocop:disable Style:ClassVars
       end

--- a/lib/dfe/analytics/initialisation_events.rb
+++ b/lib/dfe/analytics/initialisation_events.rb
@@ -36,8 +36,6 @@ module DfE
           DfE::Analytics::SendEvents.perform_now([initialise_analytics_event])
         end
 
-        DfE::Analytics::EntityTableCheckJob.perform_async if defined?(Sidekiq) && DfE::Analytics.entity_table_checks_enabled?
-
         @@initialisation_events_sent = true # rubocop:disable Style:ClassVars
       end
 

--- a/spec/dfe/analytics/entity_table_check_job_spec.rb
+++ b/spec/dfe/analytics/entity_table_check_job_spec.rb
@@ -1,86 +1,91 @@
 # frozen_string_literal: true
 
 RSpec.describe DfE::Analytics::EntityTableCheckJob do
-  # only runs if Sidekiq is installed and entity_table_check is enabled
-  if defined?(Sidekiq::Worker) && DfE::Analytics.entity_table_checks_enabled?
+  
+  include ActiveJob::TestHelper
 
-    include ActiveJob::TestHelper
+  with_model :Candidate do
+    table do |t|
+      t.string :email_address
+      t.string :first_name
+      t.string :last_name
+      t.datetime :updated_at
+    end
+  end
 
-    with_model :Candidate do
-      table do |t|
-        t.string :email_address
-        t.string :first_name
-        t.string :last_name
-        t.datetime :updated_at
-      end
+  before do
+    DfE::Analytics.config.entity_table_checks_enabled = true
+    allow(DfE::Analytics::SendEvents).to receive(:perform_async)
+    allow(DfE::Analytics).to receive(:allowlist).and_return({
+    Candidate.table_name.to_sym => %w[id]
+    })
+    allow(DfE::Analytics).to receive(:allowlist_pii).and_return({
+    Candidate.table_name.to_sym => %w[]
+    })
+    allow(Rails.logger).to receive(:info)
+    allow(Time).to receive(:now).and_return(time_now)
+  end
+
+  describe '#perform' do
+    let(:wait_time) { Date.tomorrow.midnight }
+    let(:time_now) { Time.new(2023, 9, 19, 12, 0, 0) }
+    let(:time_zone) { 'London' }
+    let(:checksum_calculated_at) { time_now.in_time_zone(time_zone).iso8601(6) }
+
+    it 'does not run if entity table check is disabled' do
+      DfE::Analytics.config.entity_table_checks_enabled = false
+
+      described_class.new.perform
+
+      expect(DfE::Analytics::SendEvents).not_to have_received(:perform_async)
     end
 
-    before do
-      allow(DfE::Analytics::EntityTableCheckJob).to receive(:perform_later)
-      allow(DfE::Analytics::SendEvents).to receive(:perform_later)
-      allow(DfE::Analytics).to receive(:allowlist).and_return({
-      Candidate.table_name.to_sym => %w[id]
-      })
-      allow(DfE::Analytics).to receive(:allowlist_pii).and_return({
-      Candidate.table_name.to_sym => %w[]
-      })
-      allow(Rails.logger).to receive(:info)
-      allow(Time).to receive(:now).and_return(time_now)
+    it 'sends the entity_table_check event to BigQuery' do
+      [123, 124, 125].map { |id| Candidate.create(id: id) }
+      table_ids = Candidate.where('updated_at < ?', Time.parse(checksum_calculated_at)).order(updated_at: :asc).pluck(:id)
+      checksum = Digest::SHA256.hexdigest(table_ids.join)
+      described_class.new.perform
+
+      expect(DfE::Analytics::SendEvents).to have_received(:perform_async)
+        .with([a_hash_including({
+          'entity_table_name' => Candidate.table_name,
+          'event_type' => 'entity_table_check',
+          'data' => [
+            { 'key' => 'row_count', 'value' => [table_ids.size] },
+            { 'key' => 'checksum', 'value' => [checksum] },
+            { 'key' => 'checksum_calculated_at', 'value' => [checksum_calculated_at] }
+          ]
+      })])
     end
 
-    describe '#perform' do
-      let(:wait_time) { Date.tomorrow.midnight }
-      let(:time_now) { Time.new(2023, 9, 19, 12, 0, 0) }
-      let(:time_zone) { 'London' }
-      let(:checksum_calculated_at) { time_now.in_time_zone(time_zone).iso8601(6) }
+    it 'does not send the event if updated_at is greater than checksum_calculated_at' do
+      checksum_calculated_at = Time.parse(time_now.in_time_zone(time_zone).iso8601(6))
+      Candidate.create(id: '123', updated_at: checksum_calculated_at - 2.hours)
+      Candidate.create(id: '124', updated_at: checksum_calculated_at - 5.hours)
+      Candidate.create(id: '125', updated_at: checksum_calculated_at + 5.hours)
 
-      it 'sends the entity_table_check event to BigQuery' do
-        [123, 124, 125].map { |id| Candidate.create(id: id) }
-        table_ids = Candidate.where('updated_at < ?', Time.parse(checksum_calculated_at)).order(updated_at: :asc).pluck(:id)
-        checksum = Digest::SHA256.hexdigest(table_ids.join)
-        described_class.new.perform
+      table_ids = Candidate.where('updated_at < ?', checksum_calculated_at).order(updated_at: :asc).pluck(:id)
+      checksum = Digest::SHA256.hexdigest(table_ids.join)
+      described_class.new.perform
 
-        expect(DfE::Analytics::SendEvents).to have_received(:perform_later)
-          .with([a_hash_including({
-            'entity_table_name' => Candidate.table_name,
-            'event_type' => 'entity_table_check',
-            'data' => [
-              { 'key' => 'row_count', 'value' => [table_ids.size] },
-              { 'key' => 'checksum', 'value' => [checksum] },
-              { 'key' => 'checksum_calculated_at', 'value' => [checksum_calculated_at] }
-            ]
-        })])
-      end
+      expect(DfE::Analytics::SendEvents).to have_received(:perform_async)
+        .with([a_hash_including({
+          'entity_table_name' => Candidate.table_name,
+          'event_type' => 'entity_table_check',
+          'data' => [
+            { 'key' => 'row_count', 'value' => [table_ids.size] },
+            { 'key' => 'checksum', 'value' => [checksum] },
+            { 'key' => 'checksum_calculated_at', 'value' => [checksum_calculated_at] }
+          ]
+      })])
+    end
 
-      it 'does not send the event if updated_at is greater than checksum_calculated_at' do
-        checksum_calculated_at = Time.parse(time_now.in_time_zone(time_zone).iso8601(6))
-        Candidate.create(id: '123', updated_at: checksum_calculated_at - 2.hours)
-        Candidate.create(id: '124', updated_at: checksum_calculated_at - 5.hours)
-        Candidate.create(id: '125', updated_at: checksum_calculated_at + 5.hours)
+    it 'logs the entity name and row count' do
+      Candidate.create(id: 123)
+      described_class.new.perform
 
-        table_ids = Candidate.where('updated_at < ?', checksum_calculated_at).order(updated_at: :asc).pluck(:id)
-        checksum = Digest::SHA256.hexdigest(table_ids.join)
-        described_class.new.perform
-
-        expect(DfE::Analytics::SendEvents).to have_received(:perform_later)
-          .with([a_hash_including({
-            'entity_table_name' => Candidate.table_name,
-            'event_type' => 'entity_table_check',
-            'data' => [
-              { 'key' => 'row_count', 'value' => [table_ids.size] },
-              { 'key' => 'checksum', 'value' => [checksum] },
-              { 'key' => 'checksum_calculated_at', 'value' => [checksum_calculated_at] }
-            ]
-        })])
-      end
-
-      it 'logs the entity name and row count' do
-        Candidate.create(id: 123)
-        described_class.new.perform
-
-        expect(Rails.logger).to have_received(:info)
-        .with("Processing data for #{Candidate.table_name} with row count #{Candidate.count}")
-      end
+      expect(Rails.logger).to have_received(:info)
+      .with("Processing data for #{Candidate.table_name} with row count #{Candidate.count}")
     end
   end
 end

--- a/spec/dfe/analytics/entity_table_check_job_spec.rb
+++ b/spec/dfe/analytics/entity_table_check_job_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe DfE::Analytics::EntityTableCheckJob do
-  
   include ActiveJob::TestHelper
 
   with_model :Candidate do

--- a/spec/dfe/analytics/entity_table_check_job_spec.rb
+++ b/spec/dfe/analytics/entity_table_check_job_spec.rb
@@ -1,94 +1,86 @@
 # frozen_string_literal: true
 
 RSpec.describe DfE::Analytics::EntityTableCheckJob do
-  include ActiveJob::TestHelper
+  # only runs if Sidekiq is installed and entity_table_check is enabled
+  if defined?(Sidekiq::Worker) && DfE::Analytics.entity_table_checks_enabled?
+  
+    include ActiveJob::TestHelper
 
-  with_model :Candidate do
-    table do |t|
-      t.string :email_address
-      t.string :first_name
-      t.string :last_name
-      t.datetime :updated_at
-    end
-  end
-
-  before do
-    allow(DfE::Analytics::EntityTableCheckJob).to receive(:perform_later)
-    allow(DfE::Analytics::SendEvents).to receive(:perform_later)
-    allow(DfE::Analytics).to receive(:allowlist).and_return({
-    Candidate.table_name.to_sym => %w[id]
-    })
-    allow(DfE::Analytics).to receive(:allowlist_pii).and_return({
-    Candidate.table_name.to_sym => %w[]
-    })
-    allow(Rails.logger).to receive(:info)
-    allow(Time).to receive(:now).and_return(time_now)
-  end
-
-  describe '#perform' do
-    let(:wait_time) { Date.tomorrow.midnight }
-    let(:time_now) { Time.new(2023, 9, 19, 12, 0, 0) }
-    let(:time_zone) { 'London' }
-    let(:checksum_calculated_at) { time_now.in_time_zone(time_zone).iso8601(6) }
-
-    it 'sends the entity_table_check event to BigQuery' do
-      [123, 124, 125].map { |id| Candidate.create(id: id) }
-      table_ids = Candidate.where('updated_at < ?', Time.parse(checksum_calculated_at)).order(updated_at: :asc).pluck(:id)
-      checksum = Digest::SHA256.hexdigest(table_ids.join)
-      described_class.new.perform
-
-      expect(DfE::Analytics::SendEvents).to have_received(:perform_later)
-        .with([a_hash_including({
-          'entity_table_name' => Candidate.table_name,
-          'event_type' => 'entity_table_check',
-          'data' => [
-            { 'key' => 'row_count', 'value' => [table_ids.size] },
-            { 'key' => 'checksum', 'value' => [checksum] },
-            { 'key' => 'checksum_calculated_at', 'value' => [checksum_calculated_at] }
-          ]
-      })])
+    with_model :Candidate do
+      table do |t|
+        t.string :email_address
+        t.string :first_name
+        t.string :last_name
+        t.datetime :updated_at
+      end
     end
 
-    it 'does not send the event if updated_at is greater than checksum_calculated_at' do
-      checksum_calculated_at = Time.parse(time_now.in_time_zone(time_zone).iso8601(6))
-      Candidate.create(id: '123', updated_at: checksum_calculated_at - 2.hours)
-      Candidate.create(id: '124', updated_at: checksum_calculated_at - 5.hours)
-      Candidate.create(id: '125', updated_at: checksum_calculated_at + 5.hours)
-
-      table_ids = Candidate.where('updated_at < ?', checksum_calculated_at).order(updated_at: :asc).pluck(:id)
-      checksum = Digest::SHA256.hexdigest(table_ids.join)
-      described_class.new.perform
-
-      expect(DfE::Analytics::SendEvents).to have_received(:perform_later)
-        .with([a_hash_including({
-          'entity_table_name' => Candidate.table_name,
-          'event_type' => 'entity_table_check',
-          'data' => [
-            { 'key' => 'row_count', 'value' => [table_ids.size] },
-            { 'key' => 'checksum', 'value' => [checksum] },
-            { 'key' => 'checksum_calculated_at', 'value' => [checksum_calculated_at] }
-          ]
-      })])
+    before do
+      allow(DfE::Analytics::EntityTableCheckJob).to receive(:perform_later)
+      allow(DfE::Analytics::SendEvents).to receive(:perform_later)
+      allow(DfE::Analytics).to receive(:allowlist).and_return({
+      Candidate.table_name.to_sym => %w[id]
+      })
+      allow(DfE::Analytics).to receive(:allowlist_pii).and_return({
+      Candidate.table_name.to_sym => %w[]
+      })
+      allow(Rails.logger).to receive(:info)
+      allow(Time).to receive(:now).and_return(time_now)
     end
 
-    it 'reschedules the job to the expected wait time' do
-      expected_time = Date.tomorrow.midnight.to_i
-      described_class.new.perform
+    describe '#perform' do
+      let(:wait_time) { Date.tomorrow.midnight }
+      let(:time_now) { Time.new(2023, 9, 19, 12, 0, 0) }
+      let(:time_zone) { 'London' }
+      let(:checksum_calculated_at) { time_now.in_time_zone(time_zone).iso8601(6) }
 
-      assert_enqueued_with(job: described_class) do
-        described_class.set(wait_until: wait_time).perform_later
+      it 'sends the entity_table_check event to BigQuery' do
+        [123, 124, 125].map { |id| Candidate.create(id: id) }
+        table_ids = Candidate.where('updated_at < ?', Time.parse(checksum_calculated_at)).order(updated_at: :asc).pluck(:id)
+        checksum = Digest::SHA256.hexdigest(table_ids.join)
+        described_class.new.perform
+
+        expect(DfE::Analytics::SendEvents).to have_received(:perform_later)
+          .with([a_hash_including({
+            'entity_table_name' => Candidate.table_name,
+            'event_type' => 'entity_table_check',
+            'data' => [
+              { 'key' => 'row_count', 'value' => [table_ids.size] },
+              { 'key' => 'checksum', 'value' => [checksum] },
+              { 'key' => 'checksum_calculated_at', 'value' => [checksum_calculated_at] }
+            ]
+        })])
       end
 
-      enqueued_job = ActiveJob::Base.queue_adapter.enqueued_jobs.last
-      expect(enqueued_job[:at].to_i).to be_within(2).of(expected_time)
-    end
+      it 'does not send the event if updated_at is greater than checksum_calculated_at' do
+        checksum_calculated_at = Time.parse(time_now.in_time_zone(time_zone).iso8601(6))
+        Candidate.create(id: '123', updated_at: checksum_calculated_at - 2.hours)
+        Candidate.create(id: '124', updated_at: checksum_calculated_at - 5.hours)
+        Candidate.create(id: '125', updated_at: checksum_calculated_at + 5.hours)
 
-    it 'logs the entity name and row count' do
-      Candidate.create(id: 123)
-      described_class.new.perform
+        table_ids = Candidate.where('updated_at < ?', checksum_calculated_at).order(updated_at: :asc).pluck(:id)
+        checksum = Digest::SHA256.hexdigest(table_ids.join)
+        described_class.new.perform
 
-      expect(Rails.logger).to have_received(:info)
-      .with("Processing data for #{Candidate.table_name} with row count #{Candidate.count}")
+        expect(DfE::Analytics::SendEvents).to have_received(:perform_later)
+          .with([a_hash_including({
+            'entity_table_name' => Candidate.table_name,
+            'event_type' => 'entity_table_check',
+            'data' => [
+              { 'key' => 'row_count', 'value' => [table_ids.size] },
+              { 'key' => 'checksum', 'value' => [checksum] },
+              { 'key' => 'checksum_calculated_at', 'value' => [checksum_calculated_at] }
+            ]
+        })])
+      end
+
+      it 'logs the entity name and row count' do
+        Candidate.create(id: 123)
+        described_class.new.perform
+
+        expect(Rails.logger).to have_received(:info)
+        .with("Processing data for #{Candidate.table_name} with row count #{Candidate.count}")
+      end
     end
   end
 end

--- a/spec/dfe/analytics/entity_table_check_job_spec.rb
+++ b/spec/dfe/analytics/entity_table_check_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DfE::Analytics::EntityTableCheckJob do
 
   before do
     DfE::Analytics.config.entity_table_checks_enabled = true
-    allow(DfE::Analytics::SendEvents).to receive(:perform_async)
+    allow(DfE::Analytics::SendEvents).to receive(:perform_later)
     allow(DfE::Analytics).to receive(:allowlist).and_return({
     Candidate.table_name.to_sym => %w[id]
     })
@@ -36,7 +36,7 @@ RSpec.describe DfE::Analytics::EntityTableCheckJob do
 
       described_class.new.perform
 
-      expect(DfE::Analytics::SendEvents).not_to have_received(:perform_async)
+      expect(DfE::Analytics::SendEvents).not_to have_received(:perform_later)
     end
 
     it 'sends the entity_table_check event to BigQuery' do
@@ -45,7 +45,7 @@ RSpec.describe DfE::Analytics::EntityTableCheckJob do
       checksum = Digest::SHA256.hexdigest(table_ids.join)
       described_class.new.perform
 
-      expect(DfE::Analytics::SendEvents).to have_received(:perform_async)
+      expect(DfE::Analytics::SendEvents).to have_received(:perform_later)
         .with([a_hash_including({
           'entity_table_name' => Candidate.table_name,
           'event_type' => 'entity_table_check',
@@ -67,7 +67,7 @@ RSpec.describe DfE::Analytics::EntityTableCheckJob do
       checksum = Digest::SHA256.hexdigest(table_ids.join)
       described_class.new.perform
 
-      expect(DfE::Analytics::SendEvents).to have_received(:perform_async)
+      expect(DfE::Analytics::SendEvents).to have_received(:perform_later)
         .with([a_hash_including({
           'entity_table_name' => Candidate.table_name,
           'event_type' => 'entity_table_check',

--- a/spec/dfe/analytics/entity_table_check_job_spec.rb
+++ b/spec/dfe/analytics/entity_table_check_job_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe DfE::Analytics::EntityTableCheckJob do
   # only runs if Sidekiq is installed and entity_table_check is enabled
   if defined?(Sidekiq::Worker) && DfE::Analytics.entity_table_checks_enabled?
-  
+
     include ActiveJob::TestHelper
 
     with_model :Candidate do

--- a/spec/dfe/analytics/initialisation_events_spec.rb
+++ b/spec/dfe/analytics/initialisation_events_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe DfE::Analytics::InitialisationEvents do
   before do
     allow(DfE::Analytics::SendEvents).to receive(:perform_later)
     allow(DfE::Analytics.config).to receive(:entity_table_checks_enabled).and_return(true)
-    allow(DfE::Analytics::EntityTableCheckJob).to receive(:perform_later)
     allow(DfE::Analytics).to receive(:enabled?).and_return(true)
     described_class.trigger_initialisation_events
   end
@@ -20,12 +19,6 @@ RSpec.describe DfE::Analytics::InitialisationEvents do
               'value' => ['{"pseudonymise_web_request_user_id":false,"entity_table_checks_enabled":true}'] }
           ]
         })])
-    end
-
-    if defined?(Sidekiq::Worker) && DfE::Analytics.entity_table_checks_enabled?
-      it 'calls the entity_table_check_job' do
-        expect(DfE::Analytics::EntityTableCheckJob).to have_received(:perform_later)
-      end
     end
   end
 

--- a/spec/dfe/analytics/initialisation_events_spec.rb
+++ b/spec/dfe/analytics/initialisation_events_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe DfE::Analytics::InitialisationEvents do
       it 'calls the entity_table_check_job' do
         expect(DfE::Analytics::EntityTableCheckJob).to have_received(:perform_later)
       end
-    end  
+    end
   end
 
   describe '.initialisation_events_sent=' do

--- a/spec/dfe/analytics/initialisation_events_spec.rb
+++ b/spec/dfe/analytics/initialisation_events_spec.rb
@@ -22,9 +22,11 @@ RSpec.describe DfE::Analytics::InitialisationEvents do
         })])
     end
 
-    it 'calls the entity_table_check_job' do
-      expect(DfE::Analytics::EntityTableCheckJob).to have_received(:perform_later)
-    end
+    if defined?(Sidekiq::Worker) && DfE::Analytics.entity_table_checks_enabled?
+      it 'calls the entity_table_check_job' do
+        expect(DfE::Analytics::EntityTableCheckJob).to have_received(:perform_later)
+      end
+    end  
   end
 
   describe '.initialisation_events_sent=' do

--- a/spec/requests/analytics_spec.rb
+++ b/spec/requests/analytics_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe 'Analytics flow', type: :request do
             expect(payload.except('occurred_at')).to match(a_hash_including(entity_table_check_event.stringify_keys))
           end).to have_been_made
         end
-        
+
         expect(request_event_post.with do |req|
           body = JSON.parse(req.body)
           payload = body['rows'].first['json']

--- a/spec/requests/analytics_spec.rb
+++ b/spec/requests/analytics_spec.rb
@@ -38,11 +38,6 @@ RSpec.describe 'Analytics flow', type: :request do
     # autogenerate a compliant blocklist
     allow(DfE::Analytics).to receive(:blocklist).and_return(DfE::Analytics::Fields.generate_blocklist)
 
-    if defined?(Sidekiq::Worker) && DfE::Analytics.entity_table_checks_enabled?
-      allow(DfE::Analytics.config).to receive(:entity_table_checks_enabled).and_return(true)
-      allow_any_instance_of(DfE::Analytics::EntityTableCheckJob).to receive(:reschedule_job)
-    end
-
     DfE::Analytics.initialize!
 
     Rails.application.routes.draw do
@@ -65,7 +60,6 @@ RSpec.describe 'Analytics flow', type: :request do
     let!(:initialise_event_post) { stub_analytics_event_submission.with(body: /initialise_analytics/) }
     let!(:request_event_post) { stub_analytics_event_submission.with(body: /request_path/) }
     let!(:model_event_post) { stub_analytics_event_submission.with(body: /create_entity/) }
-    let!(:entity_table_check_event_post) { stub_analytics_event_submission.with(body: /"event_type":"entity_table_check"/) }
 
     let(:initialise_event) do
       {
@@ -91,14 +85,6 @@ RSpec.describe 'Analytics flow', type: :request do
       }
     end
 
-    let(:entity_table_check_event) do
-      {
-        environment: 'test',
-        event_type: 'entity_table_check',
-        entity_table_name: Candidate.table_name
-      }
-    end
-
     before do
       DfE::Analytics::InitialisationEvents.initialisation_events_sent = initialisation_events_sent
 
@@ -118,14 +104,6 @@ RSpec.describe 'Analytics flow', type: :request do
           payload = body['rows'].first['json']
           expect(payload.except('occurred_at')).to match(a_hash_including(initialise_event.stringify_keys))
         end).to have_been_made
-
-        if defined?(Sidekiq::Worker) && DfE::Analytics.entity_table_checks_enabled?
-          expect(entity_table_check_event_post.with do |req|
-            body = JSON.parse(req.body)
-            payload = body['rows'].first['json']
-            expect(payload.except('occurred_at')).to match(a_hash_including(entity_table_check_event.stringify_keys))
-          end).to have_been_made
-        end
 
         expect(request_event_post.with do |req|
           body = JSON.parse(req.body)
@@ -152,8 +130,6 @@ RSpec.describe 'Analytics flow', type: :request do
         request_uuid = nil # we'll compare this across requests
 
         expect(initialise_event_post).to_not have_been_made
-
-        expect(entity_table_check_event_post).to_not have_been_made
 
         expect(request_event_post.with do |req|
           body = JSON.parse(req.body)


### PR DESCRIPTION
The previous iteration of this was low maintenance self-scheduling but when tested on Register, it was not scheduling properly. 

This iteration is for services who have Sidekiq and Sidekiq cron already installed (or who want to install them). 

Syntax is updated to work with Sidekiq and README.rb is updated to give instructions on how to set up the job.

Services will have more control over scheduling and the job will be more reliable.