### PR TITLE
Update deprecated exponentially_longer method

### DIFF
--- a/lib/dfe/analytics/analytics_job.rb
+++ b/lib/dfe/analytics/analytics_job.rb
@@ -2,7 +2,9 @@ module DfE
   module Analytics
     class AnalyticsJob < ActiveJob::Base
       queue_as { DfE::Analytics.config.queue }
-      retry_on StandardError, wait: :exponentially_longer, attempts: 5
+
+      wait_option = Rails::VERSION::STRING >= '7.1' ? :polynomially_longer : :exponentially_longer
+      retry_on StandardError, wait: wait_option, attempts: 5
     end
   end
 end


### PR DESCRIPTION
This method is deprecated in Rails 7.1 and will be removed in Rails 7.2.
https://github.com/rails/rails/blob/7-1-stable/activejob/CHANGELOG.md#rails-710rc1-september-27-2023