### PR TITLE
Update lookup to SQL if postgres db

### DIFF
--- a/lib/dfe/analytics/entity_table_check_job.rb
+++ b/lib/dfe/analytics/entity_table_check_job.rb
@@ -35,11 +35,11 @@ module DfE
         checksum_calculated_at = fetch_current_timestamp_in_time_zone
 
         row_count, checksum = fetch_checksum_data(model, adapter_name, checksum_calculated_at)
-        {
-          row_count: row_count,
-          checksum: checksum,
-          checksum_calculated_at: checksum_calculated_at
-        }
+          { 
+            row_count: row_count, 
+            checksum: checksum, 
+            checksum_calculated_at: checksum_calculated_at 
+          }
       end
 
       def supported_adapter_and_environment?(adapter_name)
@@ -52,7 +52,7 @@ module DfE
 
       def fetch_current_timestamp_in_time_zone
         result = ActiveRecord::Base.connection.select_all('SELECT CURRENT_TIMESTAMP AS current_timestamp')
-        result.first['current_timestamp'].in_time_zone(TIME_ZONE)
+        result.first['current_timestamp'].in_time_zone(TIME_ZONE).iso8601(6)
       end
 
       def fetch_checksum_data(model, adapter_name, checksum_calculated_at)
@@ -68,7 +68,7 @@ module DfE
         checksum_calculated_at_sanitized = ActiveRecord::Base.connection.quote(checksum_calculated_at)
         checksum_sql_query = <<-SQL
           SELECT COUNT(*) as row_count,
-            MD5(STRING_AGG(CHECKSUM_TABLE.ID, '' ORDER BY CHECKSUM_TABLE.UPDATED_AT )) as checksum
+            MD5(COALESCE(STRING_AGG(CHECKSUM_TABLE.ID, '' ORDER BY CHECKSUM_TABLE.UPDATED_AT), '')) as checksum
           FROM (
             SELECT #{sanitized_table_name}.id::TEXT as ID,
                    #{sanitized_table_name}.updated_at as UPDATED_AT

--- a/lib/dfe/analytics/entity_table_check_job.rb
+++ b/lib/dfe/analytics/entity_table_check_job.rb
@@ -14,9 +14,9 @@ module DfE
         DfE::Analytics.entities_for_analytics.each do |entity_name|
           DfE::Analytics.models_for_entity(entity_name).each do |model|
             entity_table_check_event = DfE::Analytics::Event.new
-                                                            .with_data(entity_table_check_data(model))
                                                             .with_type('entity_table_check')
                                                             .with_entity_table_name(model.table_name)
+                                                            .with_data(entity_table_check_data(model))
                                                             .as_json
             DfE::Analytics::SendEvents.perform_later([entity_table_check_event])
             Rails.logger.info("Processing data for #{model.table_name} with row count #{model.count}")
@@ -25,36 +25,48 @@ module DfE
       end
 
       def entity_table_check_data(model)
-        checksum_calculated_at = Time.now.in_time_zone(TIME_ZONE).iso8601
+        checksum_calculated_at = Time.now.in_time_zone(TIME_ZONE).iso8601(6)
+        adapter_name = ActiveRecord::Base.connection.adapter_name.downcase
+        row_count, checksum = fetch_checksum_data(model, checksum_calculated_at, adapter_name)
 
-        if ActiveRecord::Base.connection.adapter_name.downcase == 'postgresql'
-          sql_query = <<-SQL
-            SELECT MD5(STRING_AGG(CHECKSUM_TABLE.ID, ''))
-            FROM
-            (SELECT #{model.table_name}.id::TEXT as ID
-            FROM #{model.table_name}
-            WHERE #{model.table_name}.updated_at < ?
-            ORDER BY #{model.table_name}.updated_at ASC) CHECKSUM_TABLE
-          SQL
+        {
+          row_count: row_count,
+          checksum: checksum,
+          checksum_calculated_at: checksum_calculated_at
+        }
+      end
 
-          result = ActiveRecord::Base.connection.execute(sql_query, Time.parse(checksum_calculated_at)).first
-          {
-            row_count: result['row_count'].to_i,
-            checksum: result['checksum'],
-            checksum_calculated_at: checksum_calculated_at
-          }
+      def fetch_checksum_data(model, checksum_calculated_at, adapter_name)
+        if adapter_name == 'postgresql'
+          fetch_postgresql_checksum_data(model, checksum_calculated_at)
         else
-          table_ids =
-            model
-            .where('updated_at < ?', Time.parse(checksum_calculated_at))
-            .order(updated_at: :asc)
-            .pluck(:id)
-          {
-            row_count: table_ids.count,
-            checksum: Digest::SHA256.hexdigest(table_ids.join),
-            checksum_calculated_at: checksum_calculated_at
-          }
+          fetch_generic_checksum_data(model, checksum_calculated_at)
         end
+      end
+
+      def fetch_postgresql_checksum_data(model, checksum_calculated_at)
+        checksum_sql_query = <<-SQL
+          SELECT COUNT(*) as row_count,
+            MD5(STRING_AGG(CHECKSUM_TABLE.ID, '')) as checksum
+          FROM (
+            SELECT #{model.table_name}.id::TEXT as ID
+            FROM #{model.table_name}
+            WHERE #{model.table_name}.updated_at < '#{checksum_calculated_at}'
+            ORDER BY #{model.table_name}.updated_at ASC
+          ) CHECKSUM_TABLE
+        SQL
+
+        result = ActiveRecord::Base.connection.execute(checksum_sql_query).first
+        [result['row_count'].to_i, result['checksum']]
+      end
+
+      def fetch_generic_checksum_data(model, checksum_calculated_at)
+        table_ids =
+          model
+          .where('updated_at < ?', Time.parse(checksum_calculated_at))
+          .order(updated_at: :asc)
+          .pluck(:id)
+        [table_ids.count, Digest::SHA256.hexdigest(table_ids.join)]
       end
     end
   end

--- a/lib/dfe/analytics/entity_table_check_job.rb
+++ b/lib/dfe/analytics/entity_table_check_job.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'active_support/values/time_zone'
-require 'pry'
 
 module DfE
   module Analytics
@@ -65,15 +64,16 @@ module DfE
       end
 
       def fetch_postgresql_checksum_data(model, checksum_calculated_at)
+        sanitized_table_name = ActiveRecord::Base.connection.quote_table_name(model.table_name)
         checksum_calculated_at_sanitized = ActiveRecord::Base.connection.quote(checksum_calculated_at)
         checksum_sql_query = <<-SQL
           SELECT COUNT(*) as row_count,
             MD5(STRING_AGG(CHECKSUM_TABLE.ID, '' ORDER BY CHECKSUM_TABLE.UPDATED_AT )) as checksum
           FROM (
-            SELECT #{model.table_name}.id::TEXT as ID,
-                   #{model.table_name}.updated_at as UPDATED_AT
-            FROM #{model.table_name}
-            WHERE #{model.table_name}.updated_at < #{checksum_calculated_at_sanitized}
+            SELECT #{sanitized_table_name}.id::TEXT as ID,
+                   #{sanitized_table_name}.updated_at as UPDATED_AT
+            FROM #{sanitized_table_name}
+            WHERE #{sanitized_table_name}.updated_at < #{checksum_calculated_at_sanitized}
           ) CHECKSUM_TABLE
         SQL
 

--- a/lib/dfe/analytics/entity_table_check_job.rb
+++ b/lib/dfe/analytics/entity_table_check_job.rb
@@ -35,11 +35,11 @@ module DfE
         checksum_calculated_at = fetch_current_timestamp_in_time_zone
 
         row_count, checksum = fetch_checksum_data(model, adapter_name, checksum_calculated_at)
-          { 
-            row_count: row_count, 
-            checksum: checksum, 
-            checksum_calculated_at: checksum_calculated_at 
-          }
+        {
+          row_count: row_count,
+          checksum: checksum,
+          checksum_calculated_at: checksum_calculated_at
+        }
       end
 
       def supported_adapter_and_environment?(adapter_name)
@@ -68,7 +68,7 @@ module DfE
         checksum_calculated_at_sanitized = ActiveRecord::Base.connection.quote(checksum_calculated_at)
         checksum_sql_query = <<-SQL
           SELECT COUNT(*) as row_count,
-            MD5(COALESCE(STRING_AGG(CHECKSUM_TABLE.ID, '' ORDER BY CHECKSUM_TABLE.UPDATED_AT), '')) as checksum
+            MD5(COALESCE(STRING_AGG(CHECKSUM_TABLE.ID, '' ORDER BY CHECKSUM_TABLE.UPDATED_AT ASC), '')) as checksum
           FROM (
             SELECT #{sanitized_table_name}.id::TEXT as ID,
                    #{sanitized_table_name}.updated_at as UPDATED_AT

--- a/lib/dfe/analytics/entity_table_check_job.rb
+++ b/lib/dfe/analytics/entity_table_check_job.rb
@@ -26,20 +26,18 @@ module DfE
 
       def entity_table_check_data(model)
         adapter_name = ActiveRecord::Base.connection.adapter_name.downcase
-        return_unless_postgres_in_production?(adapter_name)
+
+        if adapter_name != 'postgresql' && Rails.env.production?
+          Rails.logger.info('DfE::Analytics: Entity checksum: Only Postgres databases supported on PRODUCTION')
+          return
+        end
+
         row_count, checksum, checksum_calculated_at = fetch_checksum_data(model, adapter_name)
         {
           row_count: row_count,
           checksum: checksum,
           checksum_calculated_at: checksum_calculated_at
         }
-      end
-
-      def return_unless_postgres_in_production?(adapter_name)
-        if !(adapter_name == 'postgresql') && Rails.env.production?
-          Rails.logger.info('DfE::Analytics: Entity checksum: Only Postgres databases supported on PRODUCTION')
-          return
-        end
       end
 
       def fetch_checksum_data(model, adapter_name)

--- a/lib/dfe/analytics/entity_table_check_job.rb
+++ b/lib/dfe/analytics/entity_table_check_job.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_support/values/time_zone'
+require 'pry'
 
 module DfE
   module Analytics
@@ -13,26 +14,28 @@ module DfE
 
         DfE::Analytics.entities_for_analytics.each do |entity_name|
           DfE::Analytics.models_for_entity(entity_name).each do |model|
-            entity_table_check_event = DfE::Analytics::Event.new
-                                                            .with_type('entity_table_check')
-                                                            .with_entity_table_name(model.table_name)
-                                                            .with_data(entity_table_check_data(model))
-                                                            .as_json
+            entity_table_check_event = build_event_for(model)
             DfE::Analytics::SendEvents.perform_later([entity_table_check_event])
             Rails.logger.info("Processing data for #{model.table_name} with row count #{model.count}")
           end
         end
       end
 
+      def build_event_for(model)
+        DfE::Analytics::Event.new
+          .with_type('entity_table_check')
+          .with_entity_table_name(model.table_name)
+          .with_data(entity_table_check_data(model))
+          .as_json
+      end
+
       def entity_table_check_data(model)
         adapter_name = ActiveRecord::Base.connection.adapter_name.downcase
+        return unless supported_adapter_and_environment?(adapter_name)
 
-        if adapter_name != 'postgresql' && Rails.env.production?
-          Rails.logger.info('DfE::Analytics: Entity checksum: Only Postgres databases supported on PRODUCTION')
-          return
-        end
+        checksum_calculated_at = fetch_current_timestamp_in_time_zone
 
-        row_count, checksum, checksum_calculated_at = fetch_checksum_data(model, adapter_name)
+        row_count, checksum = fetch_checksum_data(model, adapter_name, checksum_calculated_at)
         {
           row_count: row_count,
           checksum: checksum,
@@ -40,39 +43,51 @@ module DfE
         }
       end
 
-      def fetch_checksum_data(model, adapter_name)
+      def supported_adapter_and_environment?(adapter_name)
+        if adapter_name != 'postgresql' && Rails.env.production?
+          Rails.logger.info('DfE::Analytics: Entity checksum: Only Postgres databases supported on PRODUCTION')
+          return false
+        end
+        true
+      end
+
+      def fetch_current_timestamp_in_time_zone
+        result = ActiveRecord::Base.connection.select_all('SELECT CURRENT_TIMESTAMP AS current_timestamp')
+        result.first['current_timestamp'].in_time_zone(TIME_ZONE)
+      end
+
+      def fetch_checksum_data(model, adapter_name, checksum_calculated_at)
         if adapter_name == 'postgresql'
-          fetch_postgresql_checksum_data(model)
+          fetch_postgresql_checksum_data(model, checksum_calculated_at)
         else
-          fetch_generic_checksum_data(model)
+          fetch_generic_checksum_data(model, checksum_calculated_at)
         end
       end
 
-      def fetch_postgresql_checksum_data(model)
+      def fetch_postgresql_checksum_data(model, checksum_calculated_at)
+        checksum_calculated_at_sanitized = ActiveRecord::Base.connection.quote(checksum_calculated_at)
         checksum_sql_query = <<-SQL
           SELECT COUNT(*) as row_count,
-            MD5(STRING_AGG(CHECKSUM_TABLE.ID, '')) as checksum,
-            CURRENT_TIMESTAMP(6) as checksum_calculated_at
+            MD5(STRING_AGG(CHECKSUM_TABLE.ID, '' ORDER BY CHECKSUM_TABLE.UPDATED_AT )) as checksum
           FROM (
-            SELECT #{model.table_name}.id::TEXT as ID
+            SELECT #{model.table_name}.id::TEXT as ID,
+                   #{model.table_name}.updated_at as UPDATED_AT
             FROM #{model.table_name}
-            WHERE #{model.table_name}.updated_at < CURRENT_TIMESTAMP(6)
-            ORDER BY #{model.table_name}.updated_at ASC
+            WHERE #{model.table_name}.updated_at < #{checksum_calculated_at_sanitized}
           ) CHECKSUM_TABLE
         SQL
 
         result = ActiveRecord::Base.connection.execute(checksum_sql_query).first
-        [result['row_count'].to_i, result['checksum'], result['checksum_calculated_at']]
+        [result['row_count'].to_i, result['checksum']]
       end
 
-      def fetch_generic_checksum_data(model)
-        checksum_calculated_at = Time.now.in_time_zone(TIME_ZONE).iso8601(6)
+      def fetch_generic_checksum_data(model, checksum_calculated_at)
         table_ids =
           model
-          .where('updated_at < ?', Time.parse(checksum_calculated_at))
+          .where('updated_at < ?', checksum_calculated_at)
           .order(updated_at: :asc)
           .pluck(:id)
-        [table_ids.count, Digest::MD5.hexdigest(table_ids.join), checksum_calculated_at]
+        [table_ids.count, Digest::MD5.hexdigest(table_ids.join)]
       end
     end
   end

--- a/lib/dfe/analytics/entity_table_check_job.rb
+++ b/lib/dfe/analytics/entity_table_check_job.rb
@@ -25,10 +25,9 @@ module DfE
       end
 
       def entity_table_check_data(model)
-        checksum_calculated_at = Time.now.in_time_zone(TIME_ZONE).iso8601(6)
         adapter_name = ActiveRecord::Base.connection.adapter_name.downcase
-        row_count, checksum = fetch_checksum_data(model, checksum_calculated_at, adapter_name)
-
+        return_unless_postgres_in_production?(adapter_name)
+        row_count, checksum, checksum_calculated_at = fetch_checksum_data(model, adapter_name)
         {
           row_count: row_count,
           checksum: checksum,
@@ -36,37 +35,46 @@ module DfE
         }
       end
 
-      def fetch_checksum_data(model, checksum_calculated_at, adapter_name)
-        if adapter_name == 'postgresql'
-          fetch_postgresql_checksum_data(model, checksum_calculated_at)
-        else
-          fetch_generic_checksum_data(model, checksum_calculated_at)
+      def return_unless_postgres_in_production?(adapter_name)
+        if !(adapter_name == 'postgresql') && Rails.env.production?
+          Rails.logger.info('DfE::Analytics: Entity checksum: Only Postgres databases supported on PRODUCTION')
+          return
         end
       end
 
-      def fetch_postgresql_checksum_data(model, checksum_calculated_at)
+      def fetch_checksum_data(model, adapter_name)
+        if adapter_name == 'postgresql'
+          fetch_postgresql_checksum_data(model)
+        else
+          fetch_generic_checksum_data(model)
+        end
+      end
+
+      def fetch_postgresql_checksum_data(model)
         checksum_sql_query = <<-SQL
           SELECT COUNT(*) as row_count,
-            MD5(STRING_AGG(CHECKSUM_TABLE.ID, '')) as checksum
+            MD5(STRING_AGG(CHECKSUM_TABLE.ID, '')) as checksum,
+            CURRENT_TIMESTAMP(6) as checksum_calculated_at
           FROM (
             SELECT #{model.table_name}.id::TEXT as ID
             FROM #{model.table_name}
-            WHERE #{model.table_name}.updated_at < '#{checksum_calculated_at}'
+            WHERE #{model.table_name}.updated_at < CURRENT_TIMESTAMP(6)
             ORDER BY #{model.table_name}.updated_at ASC
           ) CHECKSUM_TABLE
         SQL
 
         result = ActiveRecord::Base.connection.execute(checksum_sql_query).first
-        [result['row_count'].to_i, result['checksum']]
+        [result['row_count'].to_i, result['checksum'], result['checksum_calculated_at']]
       end
 
-      def fetch_generic_checksum_data(model, checksum_calculated_at)
+      def fetch_generic_checksum_data(model)
+        checksum_calculated_at = Time.now.in_time_zone(TIME_ZONE).iso8601(6)
         table_ids =
           model
           .where('updated_at < ?', Time.parse(checksum_calculated_at))
           .order(updated_at: :asc)
           .pluck(:id)
-        [table_ids.count, Digest::SHA256.hexdigest(table_ids.join)]
+        [table_ids.count, Digest::MD5.hexdigest(table_ids.join), checksum_calculated_at]
       end
     end
   end

--- a/lib/dfe/analytics/entity_table_check_job.rb
+++ b/lib/dfe/analytics/entity_table_check_job.rb
@@ -14,9 +14,9 @@ module DfE
         DfE::Analytics.entities_for_analytics.each do |entity_name|
           DfE::Analytics.models_for_entity(entity_name).each do |model|
             entity_table_check_event = DfE::Analytics::Event.new
+                                                            .with_data(entity_table_check_data(model))
                                                             .with_type('entity_table_check')
                                                             .with_entity_table_name(model.table_name)
-                                                            .with_data(entity_table_check_data(model))
                                                             .as_json
             DfE::Analytics::SendEvents.perform_later([entity_table_check_event])
             Rails.logger.info("Processing data for #{model.table_name} with row count #{model.count}")
@@ -25,17 +25,36 @@ module DfE
       end
 
       def entity_table_check_data(model)
-        checksum_calculated_at = Time.now.in_time_zone(TIME_ZONE).iso8601(6)
-        table_ids =
-          model
-          .where('updated_at < ?', Time.parse(checksum_calculated_at))
-          .order(updated_at: :asc)
-          .pluck(:id)
-        {
-          row_count: table_ids.count,
-          checksum: Digest::SHA256.hexdigest(table_ids.join),
-          checksum_calculated_at: checksum_calculated_at
-        }
+        checksum_calculated_at = Time.now.in_time_zone(TIME_ZONE).iso8601
+
+        if ActiveRecord::Base.connection.adapter_name.downcase == 'postgresql'
+          sql_query = <<-SQL
+            SELECT MD5(STRING_AGG(CHECKSUM_TABLE.ID, ''))
+            FROM
+            (SELECT #{model.table_name}.id::TEXT as ID
+            FROM #{model.table_name}
+            WHERE #{model.table_name}.updated_at < ?
+            ORDER BY #{model.table_name}.updated_at ASC) CHECKSUM_TABLE
+          SQL
+
+          result = ActiveRecord::Base.connection.execute(sql_query, Time.parse(checksum_calculated_at)).first
+          {
+            row_count: result['row_count'].to_i,
+            checksum: result['checksum'],
+            checksum_calculated_at: checksum_calculated_at
+          }
+        else
+          table_ids =
+            model
+            .where('updated_at < ?', Time.parse(checksum_calculated_at))
+            .order(updated_at: :asc)
+            .pluck(:id)
+          {
+            row_count: table_ids.count,
+            checksum: Digest::SHA256.hexdigest(table_ids.join),
+            checksum_calculated_at: checksum_calculated_at
+          }
+        end
       end
     end
   end

--- a/spec/dfe/analytics/entity_table_check_job_spec.rb
+++ b/spec/dfe/analytics/entity_table_check_job_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe DfE::Analytics::EntityTableCheckJob do
     let(:wait_time) { Date.tomorrow.midnight }
     let(:time_now) { Time.new(2023, 9, 19, 12, 0, 0) }
     let(:time_zone) { 'London' }
-    let(:checksum_calculated_at) { ActiveRecord::Base.connection.select_all('SELECT CURRENT_TIMESTAMP AS current_timestamp').first['current_timestamp'].in_time_zone('London') }
+    let(:checksum_calculated_at) { ActiveRecord::Base.connection.select_all('SELECT CURRENT_TIMESTAMP AS current_timestamp').first['current_timestamp'].in_time_zone('London').iso8601(6) }
 
     it 'does not run if entity table check is disabled' do
       DfE::Analytics.config.entity_table_checks_enabled = false
@@ -57,9 +57,10 @@ RSpec.describe DfE::Analytics::EntityTableCheckJob do
     end
 
     it 'does not send the event if updated_at is greater than checksum_calculated_at' do
-      Candidate.create(id: '123', updated_at: checksum_calculated_at - 2.hours)
-      Candidate.create(id: '124', updated_at: checksum_calculated_at - 5.hours)
-      Candidate.create(id: '125', updated_at: checksum_calculated_at + 5.hours)
+      parsed_time = DateTime.parse(checksum_calculated_at)
+      Candidate.create(id: '123', updated_at: parsed_time - 2.hours)
+      Candidate.create(id: '124', updated_at: parsed_time - 5.hours)
+      Candidate.create(id: '125', updated_at: parsed_time + 5.hours)
 
       table_ids = Candidate.where('updated_at < ?', checksum_calculated_at).order(updated_at: :asc).pluck(:id)
       checksum = Digest::MD5.hexdigest(table_ids.join)
@@ -69,6 +70,21 @@ RSpec.describe DfE::Analytics::EntityTableCheckJob do
         .with([a_hash_including({
           'data' => [
             { 'key' => 'row_count', 'value' => [table_ids.size] },
+            { 'key' => 'checksum', 'value' => [checksum] },
+            { 'key' => 'checksum_calculated_at', 'value' => [checksum_calculated_at] }
+          ]
+      })])
+    end
+
+    it 'returns zero rows and checksum if table is empty' do
+      table_ids = Candidate.where('updated_at < ?', checksum_calculated_at).order(updated_at: :asc).pluck(:id)
+      checksum = Digest::MD5.hexdigest(table_ids.join)
+      described_class.new.perform
+
+      expect(DfE::Analytics::SendEvents).to have_received(:perform_later)
+        .with([a_hash_including({
+          'data' => [
+            { 'key' => 'row_count', 'value' => [0] },
             { 'key' => 'checksum', 'value' => [checksum] },
             { 'key' => 'checksum_calculated_at', 'value' => [checksum_calculated_at] }
           ]

--- a/spec/dfe/analytics/entity_table_check_job_spec.rb
+++ b/spec/dfe/analytics/entity_table_check_job_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe DfE::Analytics::EntityTableCheckJob do
       checksum_calculated_at = Time.parse(time_now.in_time_zone(time_zone).iso8601(6))
       [123, 124, 125].map { |id| Candidate.create(id: id) }
       table_ids = Candidate.where('updated_at < ?', checksum_calculated_at).order(updated_at: :asc).pluck(:id)
-      checksum = Digest::SHA256.hexdigest(table_ids.join)
+      checksum = Digest::MD5.hexdigest(table_ids.join)
       described_class.new.perform
 
       expect(DfE::Analytics::SendEvents).to have_received(:perform_later)
@@ -64,7 +64,7 @@ RSpec.describe DfE::Analytics::EntityTableCheckJob do
       Candidate.create(id: '125', updated_at: checksum_calculated_at + 5.hours)
 
       table_ids = Candidate.where('updated_at < ?', checksum_calculated_at).order(updated_at: :asc).pluck(:id)
-      checksum = Digest::SHA256.hexdigest(table_ids.join)
+      checksum = Digest::MD5.hexdigest(table_ids.join)
       described_class.new.perform
 
       expect(DfE::Analytics::SendEvents).to have_received(:perform_later)


### PR DESCRIPTION
If the production database is Postgres, to speed up the query, the entity table data / checksum lookup is updated to be entirely in SQL so that it is executed within the db. This will reduce the memory burden on Rails and also prevent the retrieval of a large number of IDs. 

It was necessary to keep the original Active Record lookup given that the test db is SQLite3 and the updated SQL is incompatible.