### PR TITLE
Update entity_check_job to loop through entities only

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,6 +354,7 @@ GEM
     sqlite3 (1.6.3-x86_64-linux)
     thor (1.2.2)
     tilt (2.2.0)
+    timecop (0.9.8)
     timeout (0.4.0)
     timers (4.3.5)
     traces (0.11.1)
@@ -394,6 +395,7 @@ DEPENDENCIES
   rubocop-rspec (~> 2.22)
   solargraph
   sqlite3
+  timecop
   webmock (~> 3.14)
   with_model
 

--- a/dfe-analytics.gemspec
+++ b/dfe-analytics.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec', '~> 2.22'
   spec.add_development_dependency 'solargraph'
   spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'timecop'
   spec.add_development_dependency 'webmock', '~> 3.14'
   spec.add_development_dependency 'with_model'
   spec.metadata['rubygems_mfa_required'] = 'true'

--- a/lib/dfe/analytics/entity_table_check_job.rb
+++ b/lib/dfe/analytics/entity_table_check_job.rb
@@ -23,7 +23,6 @@ module DfE
           return {}
         end
 
-
         DfE::Analytics::Event.new
           .with_type('entity_table_check')
           .with_entity_table_name(entity)
@@ -61,7 +60,6 @@ module DfE
       end
 
       def fetch_checksum_data(model, adapter_name, checksum_calculated_at)
-        
         if adapter_name == 'postgresql'
           fetch_postgresql_checksum_data(model, checksum_calculated_at)
         else

--- a/lib/dfe/analytics/entity_table_check_job.rb
+++ b/lib/dfe/analytics/entity_table_check_job.rb
@@ -19,7 +19,7 @@ module DfE
 
       def build_event_for(entity_name)
         model = DfE::Analytics.models_for_entity(entity_name).last
-        Rails.logger.info("Processing data for #{model.table_name} with row count #{model.count}") 
+        Rails.logger.info("Processing data for #{model.table_name} with row count #{model.count}")
 
         DfE::Analytics::Event.new
           .with_type('entity_table_check')

--- a/lib/dfe/analytics/entity_table_check_job.rb
+++ b/lib/dfe/analytics/entity_table_check_job.rb
@@ -12,15 +12,15 @@ module DfE
         return unless DfE::Analytics.entity_table_checks_enabled?
 
         DfE::Analytics.entities_for_analytics.each do |entity_name|
-          DfE::Analytics.models_for_entity(entity_name).each do |model|
-            entity_table_check_event = build_event_for(model)
-            DfE::Analytics::SendEvents.perform_later([entity_table_check_event])
-            Rails.logger.info("Processing data for #{model.table_name} with row count #{model.count}")
-          end
+          entity_table_check_event = build_event_for(entity_name)
+          DfE::Analytics::SendEvents.perform_later([entity_table_check_event])
         end
       end
 
-      def build_event_for(model)
+      def build_event_for(entity_name)
+        model = DfE::Analytics.models_for_entity(entity_name).last
+        Rails.logger.info("Processing data for #{model.table_name} with row count #{model.count}") 
+
         DfE::Analytics::Event.new
           .with_type('entity_table_check')
           .with_entity_table_name(model.table_name)

--- a/lib/dfe/analytics/entity_table_check_job.rb
+++ b/lib/dfe/analytics/entity_table_check_job.rb
@@ -21,7 +21,7 @@ module DfE
 
       def build_event_for(entity_name)
         model = DfE::Analytics.models_for_entity(entity_name).last
-        
+
         DfE::Analytics::Event.new
           .with_type('entity_table_check')
           .with_entity_table_name(model.table_name)
@@ -92,7 +92,7 @@ module DfE
       end
 
       def log_entity_processing(entity_table_check_event, entity_name)
-        row_count = entity_table_check_event["data"].find { |item| item["key"] == "row_count" }["value"].first
+        row_count = entity_table_check_event['data'].find { |item| item['key'] == 'row_count' }['value'].first
         Rails.logger.info("DfE::Analytics Processing entity: #{entity_name}: Row count: #{row_count}")
       end
     end

--- a/spec/dfe/analytics/entity_table_check_job_spec.rb
+++ b/spec/dfe/analytics/entity_table_check_job_spec.rb
@@ -3,8 +3,6 @@
 RSpec.describe DfE::Analytics::EntityTableCheckJob do
   include ActiveJob::TestHelper
 
-  require 'pry'
-
   with_model :Candidate do
     table do |t|
       t.string :email_address
@@ -95,8 +93,8 @@ RSpec.describe DfE::Analytics::EntityTableCheckJob do
 
     it 'logs the entity name and row count' do
       Candidate.create(id: 123)
-      entity_name = Candidate.table_name.to_sym
-      expected_message = "DfE::Analytics Processing entity: #{entity_name}: Row count: #{Candidate.count}"
+      entity = Candidate.table_name.to_sym
+      expected_message = "DfE::Analytics Processing entity: #{entity}: Row count: #{Candidate.count}"
 
       described_class.new.perform
 

--- a/spec/dfe/analytics/entity_table_check_job_spec.rb
+++ b/spec/dfe/analytics/entity_table_check_job_spec.rb
@@ -97,10 +97,10 @@ RSpec.describe DfE::Analytics::EntityTableCheckJob do
       Candidate.create(id: 123)
       entity_name = Candidate.table_name.to_sym
       expected_message = "DfE::Analytics Processing entity: #{entity_name}: Row count: #{Candidate.count}"
-      
+
       described_class.new.perform
 
-      expect(Rails.logger).to have_received(:info).with("#{expected_message}")
+      expect(Rails.logger).to have_received(:info).with(expected_message.to_s)
     end
   end
 end

--- a/spec/dfe/analytics/entity_table_check_job_spec.rb
+++ b/spec/dfe/analytics/entity_table_check_job_spec.rb
@@ -31,6 +31,9 @@ RSpec.describe DfE::Analytics::EntityTableCheckJob do
     let(:time_zone) { 'London' }
     let(:checksum_calculated_at) { ActiveRecord::Base.connection.select_all('SELECT CURRENT_TIMESTAMP AS current_timestamp').first['current_timestamp'].in_time_zone('London').iso8601(6) }
 
+    before { Timecop.freeze(checksum_calculated_at) }
+    after { Timecop.return }
+
     it 'does not run if entity table check is disabled' do
       DfE::Analytics.config.entity_table_checks_enabled = false
 
@@ -93,12 +96,11 @@ RSpec.describe DfE::Analytics::EntityTableCheckJob do
 
     it 'logs the entity name and row count' do
       Candidate.create(id: 123)
-      entity = Candidate.table_name.to_sym
-      expected_message = "DfE::Analytics Processing entity: #{entity}: Row count: #{Candidate.count}"
+      expected_message = "DfE::Analytics Processing entity: #{Candidate.table_name}: Row count: #{Candidate.count}"
 
       described_class.new.perform
 
-      expect(Rails.logger).to have_received(:info).with(expected_message.to_s)
+      expect(Rails.logger).to have_received(:info).with(expected_message)
     end
   end
 end

--- a/spec/dfe/analytics/entity_table_check_job_spec.rb
+++ b/spec/dfe/analytics/entity_table_check_job_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe DfE::Analytics::EntityTableCheckJob do
   include ActiveJob::TestHelper
 
+  require 'pry'
+
   with_model :Candidate do
     table do |t|
       t.string :email_address
@@ -93,10 +95,12 @@ RSpec.describe DfE::Analytics::EntityTableCheckJob do
 
     it 'logs the entity name and row count' do
       Candidate.create(id: 123)
+      entity_name = Candidate.table_name.to_sym
+      expected_message = "DfE::Analytics Processing entity: #{entity_name}: Row count: #{Candidate.count}"
+      
       described_class.new.perform
 
-      expect(Rails.logger).to have_received(:info)
-      .with("Processing data for #{Candidate.table_name} with row count #{Candidate.count}")
+      expect(Rails.logger).to have_received(:info).with("#{expected_message}")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ ENV['RAILS_SERVE_STATIC_FILES'] = 'true'
 
 require_relative '../spec/dummy/config/environment'
 require 'debug'
+require 'timecop'
 require 'rspec/rails'
 require 'webmock/rspec'
 require 'json-schema'


### PR DESCRIPTION
We noticed after testing on Register, that the entity_check_job would loop through sub-types causing an extra event to be sent to BQ.

This PR updates the perform method to loop through entities only and updates the build_event_for method to handle entity_name rather than model. The logger message had to be moved too.

