### PR TITLE
Remove fix for ignored columns

### DIFF
--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -181,7 +181,6 @@ module DfE
     def self.extract_model_attributes(model, attributes = nil)
       # if no list of attrs specified, consider all attrs belonging to this model
       attributes ||= model.attributes
-      add_ignored_columns_to_attributes(model, attributes) if model.class.ignored_columns.any?
       table_name = model.class.table_name
 
       exportable_attrs = allowlist[table_name.to_sym].presence || []
@@ -192,14 +191,6 @@ module DfE
       obfuscated_attributes = attributes.slice(*exportable_pii_attrs&.map(&:to_s))
 
       allowed_attributes.deep_merge(obfuscated_attributes.transform_values { |value| pseudonymise(value) })
-    end
-
-    def self.add_ignored_columns_to_attributes(model, attributes)
-      ignored_columns = model.class.ignored_columns
-      return attributes if ignored_columns.blank?
-
-      nil_values_hash = ignored_columns.to_h { |key| [key, nil] }
-      attributes.merge!(nil_values_hash)
     end
 
     def self.anonymise(value)


### PR DESCRIPTION
This fix was introduced to assist ECF with a STI bug where different ignored_columns on different child models (with the same parent) were not being sent to BigQuery.

The fix wasn't working all of the time and in the end the simplest solution was to remove reference to the ignored_columns in the child models so that all of the fields are being sent all of the time.

It is probably confusing to keep this code in dfe-analytics and it is unlikely to be needed by another service because usually when a column is ignored there would not be a requirement to send it to Big Query.