### PR TITLE
Release v1.11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-## [v1.11.5](https://github.com/DFE-Digital/dfe-analytics/tree/v1.11.5) (2023-12-20)
+## [v1.11.6](https://github.com/DFE-Digital/dfe-analytics/tree/v1.11.6) (2024-01-08)
 
-[Full Changelog](https://github.com/DFE-Digital/dfe-analytics/compare/v1.11.4...v1.11.5)
+[Full Changelog](https://github.com/DFE-Digital/dfe-analytics/compare/v1.11.5...v1.11.6)
 
 **Merged pull requests:**
 
+- Ensure order by column is in analytics.yml [\#106](https://github.com/DFE-Digital/dfe-analytics/pull/106) ([ericaporter](https://github.com/ericaporter))
+- release v1.11.5 [\#105](https://github.com/DFE-Digital/dfe-analytics/pull/105) ([ericaporter](https://github.com/ericaporter))
 - Update deploy / release instructions [\#104](https://github.com/DFE-Digital/dfe-analytics/pull/104) ([ericaporter](https://github.com/ericaporter))
 - Checksum ordered by update [\#102](https://github.com/DFE-Digital/dfe-analytics/pull/102) ([ericaporter](https://github.com/ericaporter))
 - Correct docs for Sidekiq CRON and fix release tag v1.11.2 [\#100](https://github.com/DFE-Digital/dfe-analytics/pull/100) ([asatwal](https://github.com/asatwal))
@@ -34,6 +36,10 @@
 - Update advice on queue config and running imports [\#65](https://github.com/DFE-Digital/dfe-analytics/pull/65) ([asatwal](https://github.com/asatwal))
 - Add anonymisation of user\_id in the web request event data [\#64](https://github.com/DFE-Digital/dfe-analytics/pull/64) ([asatwal](https://github.com/asatwal))
 - Log Matched Events [\#63](https://github.com/DFE-Digital/dfe-analytics/pull/63) ([asatwal](https://github.com/asatwal))
+
+## [v1.11.5](https://github.com/DFE-Digital/dfe-analytics/tree/v1.11.5) (2023-12-20)
+
+[Full Changelog](https://github.com/DFE-Digital/dfe-analytics/compare/v1.11.4...v1.11.5)
 
 ## [v1.11.4](https://github.com/DFE-Digital/dfe-analytics/tree/v1.11.4) (2023-12-19)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dfe-analytics (1.11.5)
+    dfe-analytics (1.11.6)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 
@@ -156,14 +156,15 @@ GEM
       google-cloud-core (~> 1.6)
       googleauth (>= 0.16.2, < 2.a)
       mini_mime (~> 1.0)
-    google-cloud-core (1.6.0)
-      google-cloud-env (~> 1.0)
+    google-cloud-core (1.6.1)
+      google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
-    google-cloud-env (1.6.0)
-      faraday (>= 0.17.3, < 3.0)
+    google-cloud-env (2.1.0)
+      faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.3.1)
-    googleauth (1.8.1)
-      faraday (>= 0.17.3, < 3.a)
+    googleauth (1.9.1)
+      faraday (>= 1.0, < 3.a)
+      google-cloud-env (~> 2.1)
       jwt (>= 1.4, < 3.0)
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)

--- a/lib/dfe/analytics/version.rb
+++ b/lib/dfe/analytics/version.rb
@@ -2,6 +2,6 @@
 
 module DfE
   module Analytics
-    VERSION = '1.11.5'
+    VERSION = '1.11.6'
   end
 end


### PR DESCRIPTION
This update ensures that the checksum lookup only uses order_by values that exist in the analytics.yml (instead of looking to the model for their presence)

It also removes ordering by ID although this may be reintroduced at a later stage.