### PR TITLE
Update conditional to handle 'postgis' db

### DIFF
--- a/lib/dfe/analytics/entity_table_check_job.rb
+++ b/lib/dfe/analytics/entity_table_check_job.rb
@@ -55,7 +55,7 @@ module DfE
       end
 
       def supported_adapter_and_environment?
-        return true if adapter_name == 'postgresql' || !Rails.env.production?
+        return true if ['postgresql', 'postgis'].include?(adapter_name) || !Rails.env.production?
 
         Rails.logger.info('DfE::Analytics: Entity checksum: Only Postgres databases supported on PRODUCTION')
 
@@ -71,7 +71,7 @@ module DfE
         table_name_sanitized = ActiveRecord::Base.connection.quote_table_name(entity)
         checksum_calculated_at_sanitized = ActiveRecord::Base.connection.quote(checksum_calculated_at)
 
-        if adapter_name == 'postgresql'
+        if ['postgresql', 'postgis'].include?(adapter_name)
           fetch_postgresql_checksum_data(table_name_sanitized, checksum_calculated_at_sanitized, order_column)
         else
           fetch_generic_checksum_data(table_name_sanitized, checksum_calculated_at_sanitized, order_column)

--- a/lib/dfe/analytics/entity_table_check_job.rb
+++ b/lib/dfe/analytics/entity_table_check_job.rb
@@ -55,7 +55,7 @@ module DfE
       end
 
       def supported_adapter_and_environment?
-        return true if ['postgresql', 'postgis'].include?(adapter_name) || !Rails.env.production?
+        return true if %w[postgresql postgis].include?(adapter_name) || !Rails.env.production?
 
         Rails.logger.info('DfE::Analytics: Entity checksum: Only Postgres databases supported on PRODUCTION')
 
@@ -71,7 +71,7 @@ module DfE
         table_name_sanitized = ActiveRecord::Base.connection.quote_table_name(entity)
         checksum_calculated_at_sanitized = ActiveRecord::Base.connection.quote(checksum_calculated_at)
 
-        if ['postgresql', 'postgis'].include?(adapter_name)
+        if %w[postgresql postgis].include?(adapter_name)
           fetch_postgresql_checksum_data(table_name_sanitized, checksum_calculated_at_sanitized, order_column)
         else
           fetch_generic_checksum_data(table_name_sanitized, checksum_calculated_at_sanitized, order_column)


### PR DESCRIPTION
Teaching vacancies use PostGIS as a db which extends the capabilities of the PostgreSQL.

The Entity Table check job is not running for them on their review app as it point to production and the adapter_name is postgis. In production the job also won't run because the conditional returns false unless it is postgres in production.

This PR updates the conditional so that the job will run if the adapter_name is postgis. This shouldn't cause any issues as postgis is an extension of postgres and so the lookup should run as it would on postgres 