### PR TITLE
Enable filtering of request query strings using `ActiveSupport::ParameterFilter`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,14 @@ user identifier proc can be defined in `config/initializers/dfe_analytics.rb`:
 DfE::Analytics.config.user_identifier = proc { |user| user&.uid }
 ```
 
+#### Filtering PII from web request query string data
+
+Query strings may be filtered using the same `Rails.application.config.filter_parameters`
+configuration you'd normally use to prevent PII leakage to logs and error handling services.
+
+To enable this option, ensure the attributes to filter are specified in `Rails.application.config.filter_parameters`.
+Then enable filtering with `DfE::Analytics.config.filter_web_request_events = true`.
+
 ### 6. Import existing data
 
 To load the current contents of your database into BigQuery, run

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -18,6 +18,7 @@ require 'dfe/analytics/version'
 require 'dfe/analytics/middleware/request_identity'
 require 'dfe/analytics/middleware/send_cached_page_request_event'
 require 'dfe/analytics/railtie'
+require 'active_support/parameter_filter'
 
 module DfE
   module Analytics
@@ -63,6 +64,8 @@ module DfE
         pseudonymise_web_request_user_id
         entity_table_checks_enabled
         rack_page_cached
+        filter_web_request_events
+        web_request_event_filter
       ]
 
       @config ||= Struct.new(*configurables).new
@@ -86,6 +89,8 @@ module DfE
       config.pseudonymise_web_request_user_id ||= false
       config.entity_table_checks_enabled      ||= false
       config.rack_page_cached                 ||= proc { |_rack_env| false }
+      config.filter_web_request_events        ||= false
+      config.web_request_event_filter         ||= ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
     end
 
     def self.initialize!
@@ -243,6 +248,14 @@ module DfE
 
     def self.entity_table_checks_enabled?
       config.entity_table_checks_enabled
+    end
+
+    def self.filter_web_request_events?
+      config.filter_web_request_events
+    end
+
+    def self.web_request_event_filter
+      config.web_request_event_filter
     end
   end
 end

--- a/lib/dfe/analytics/event.rb
+++ b/lib/dfe/analytics/event.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 require 'active_support/values/time_zone'
+require 'dfe/analytics/query_string_utilities'
 
 module DfE
   module Analytics
     class Event
+      include QueryStringUtilities
+
       EVENT_TYPES = %w[
         web_request create_entity update_entity delete_entity import_entity initialise_analytics entity_table_check
       ].freeze
@@ -37,7 +40,7 @@ module DfE
           request_user_agent: ensure_utf8(rack_request.user_agent),
           request_method: rack_request.method,
           request_path: ensure_utf8(rack_request.path),
-          request_query: hash_to_kv_pairs(Rack::Utils.parse_query(rack_request.query_string)),
+          request_query: hash_to_kv_pairs(query_string_to_hash(rack_request.query_string)),
           request_referer: ensure_utf8(rack_request.referer),
           anonymised_user_agent_and_ip: anonymised_user_agent_and_ip(rack_request)
         )

--- a/lib/dfe/analytics/query_string_utilities.rb
+++ b/lib/dfe/analytics/query_string_utilities.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module DfE
+  module Analytics
+    # Utility methods for query string processing
+    module QueryStringUtilities
+      def query_string_to_hash(query_string)
+        hash = Rack::Utils.parse_query(query_string)
+        hash = filter_query_string(hash) if DfE::Analytics.filter_web_request_events?
+        hash
+      end
+
+      def filter_query_string(hash)
+        DfE::Analytics.web_request_event_filter.filter(hash)
+      end
+    end
+  end
+end


### PR DESCRIPTION
PII can leak into DfE analytics if present in the request query string, a common case is search parameters using personal details.

This PR adds the ability to enable web request event query filtering using the standard Rails parameter filter mechanism via the `DfE::Analytics.filter_web_request_events` configuration value.

See: https://github.com/DFE-Digital/access-your-teaching-qualifications/commit/5941285add123ffbc8ab8a738305c48aad16e1a2 for a common workaround currently being used in services to mitigate this. 

It would be preferable not to replicate this workaround on a per-service basis.