### PR TITLE
Use original_fullpath for request path

### DIFF
--- a/lib/dfe/analytics/event.rb
+++ b/lib/dfe/analytics/event.rb
@@ -36,7 +36,7 @@ module DfE
           request_uuid: rack_request.uuid,
           request_user_agent: ensure_utf8(rack_request.user_agent),
           request_method: rack_request.method,
-          request_path: ensure_utf8(rack_request.path),
+          request_path: ensure_utf8(rack_request.original_fullpath.split('?').first),
           request_query: hash_to_kv_pairs(Rack::Utils.parse_query(rack_request.query_string)),
           request_referer: ensure_utf8(rack_request.referer),
           anonymised_user_agent_and_ip: anonymised_user_agent_and_ip(rack_request)

--- a/spec/dfe/analytics/event_spec.rb
+++ b/spec/dfe/analytics/event_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe DfE::Analytics::Event do
                                                'request_uuid' => '123',
                                                'request_user_agent' => 'SomeClient',
                                                'request_method' => 'GET',
-                                               'request_path' => '/',
-                                               'request_query' => [],
+                                               'request_path' => '/path',
+                                               'request_query' => [{ 'key' => 'a', 'value' => ['b'] }],
                                                'request_referer' => nil
                                              })
   end
@@ -213,8 +213,8 @@ RSpec.describe DfE::Analytics::Event do
     attrs = {
       uuid: '123',
       method: 'GET',
-      path: '/',
-      query_string: '',
+      original_fullpath: '/path?a=b',
+      query_string: 'a=b',
       referer: nil,
       user_agent: 'SomeClient',
       remote_ip: '1.2.3.4'


### PR DESCRIPTION
This changes the event to get the request path from the `original_fullpath` method rather than the `path` method. I'm making this change as the `original_fullpath` represents the path of the page as requested by the user, not necessarily the page being rendered.

In most cases the original path and the path will be the same, but there are some scenarios where it is. Specifically, when rendering a custom error page in Rails which is mounted at `/404` the path ends up being the value `/404` rather than the path which triggered the 404 page.