### PR TITLE
Add maintenance window logic

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,6 +70,6 @@ en:
         bigquery_maintenance_window:
           description: |
             Schedule a maintenance window during which no events are streamed to BigQuery
-            in the format of '22-01-2024 19:30..22-01-2024 20:30'.
+            in the format of '22-01-2024 19:30..22-01-2024 20:30' (UTC).
           default: ENV['BIGQUERY_MAINTENANCE_WINDOW']
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,3 +67,9 @@ en:
             return a boolean indicating whether the page is cached and will
             be served by rack middleware.
           default: proc { |_rack_env| false }
+        bigquery_maintenance_window:
+          description: |
+            Schedule a maintenance window during which no events are streamed to BigQuery
+            in the format of '22-01-2024 19:30..22-01-2024 20:30'.
+          default: ENV['BIGQUERY_MAINTENANCE_WINDOW']
+

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -252,8 +252,11 @@ module DfE
 
       start_str, end_str = config.bigquery_maintenance_window.split('..', 2).map(&:strip)
       begin
-        start_time = DateTime.strptime(start_str, '%d-%m-%Y %H:%M')
-        end_time = DateTime.strptime(end_str, '%d-%m-%Y %H:%M')
+        parsed_start_time = DateTime.strptime(start_str, '%d-%m-%Y %H:%M')
+        parsed_end_time = DateTime.strptime(end_str, '%d-%m-%Y %H:%M')
+
+        start_time = Time.zone.parse(parsed_start_time.to_s)
+        end_time = Time.zone.parse(parsed_end_time.to_s)
 
         if start_time > end_time
           Rails.logger.info('Start time is after end time in maintenance window configuration')
@@ -271,7 +274,14 @@ module DfE
       start_time, end_time = parse_maintenance_window
       return false unless start_time && end_time
 
-      DateTime.now.between?(start_time, end_time)
+      Time.zone.now.between?(start_time, end_time)
+    end
+
+    def self.next_scheduled_time_after_maintenance_window
+      start_time, end_time = parse_maintenance_window
+      return unless start_time && end_time
+
+      end_time + (Time.zone.now - start_time).seconds
     end
   end
 end

--- a/lib/dfe/analytics/send_events.rb
+++ b/lib/dfe/analytics/send_events.rb
@@ -18,6 +18,12 @@ module DfE
       end
 
       def perform(events)
+        if DfE::Analytics.within_maintenance_window?
+          # Delaying / Queueing events - the redis bit
+          Rails.logger.info('Within BigQuery maintenance window. Events will be queued for later processing.')
+          return
+        end
+
         if DfE::Analytics.log_only?
           # Use the Rails logger here as the job's logger is set to :warn by default
           Rails.logger.info("DfE::Analytics: #{events.inspect}")

--- a/lib/dfe/analytics/send_events.rb
+++ b/lib/dfe/analytics/send_events.rb
@@ -10,7 +10,9 @@ module DfE
 
         events = events.map { |event| event.is_a?(Event) ? event.as_json : event }
 
-        if DfE::Analytics.async?
+        if DfE::Analytics.within_maintenance_window?
+          set(wait_until: DfE::Analytics.next_scheduled_time_after_maintenance_window).perform_later(events)
+        elsif DfE::Analytics.async?
           perform_later(events)
         else
           perform_now(events)
@@ -18,12 +20,6 @@ module DfE
       end
 
       def perform(events)
-        if DfE::Analytics.within_maintenance_window?
-          # Delaying / Queueing events - the redis bit
-          Rails.logger.info('Within BigQuery maintenance window. Events will be queued for later processing.')
-          return
-        end
-
         if DfE::Analytics.log_only?
           # Use the Rails logger here as the job's logger is set to :warn by default
           Rails.logger.info("DfE::Analytics: #{events.inspect}")


### PR DESCRIPTION
Relating to this [ticket ](https://trello.com/c/LacYDk5E/1802-dfe-analytics-support-scheduled-downtime-for-bigquery)

We need the ability to do maintenance on on a live streamed BiqQuery dataset, such as register_events_production.

This PR adds a configuration item for a maintenance window.

Redis logic - WIP
- On reaching the start maintenance window start timestamp, DfE Analytics will start queueing items with a schedule time of:
end_timestamp + number of seconds elapsed since start_timestamp
The queued items will end up queued in Redis.
- Once the end of the maintenance window is reached, the queue items will be processed and sent to BigQuery and a First In First Out (FIFO) base.

