### PR TITLE
Remove array brackets for unused event tag

### DIFF
--- a/lib/dfe/analytics/entities.rb
+++ b/lib/dfe/analytics/entities.rb
@@ -37,7 +37,7 @@ module DfE
                                      .with_type(type)
                                      .with_entity_table_name(self.class.table_name)
                                      .with_data(data)
-                                     .with_tags([event_tags])
+                                     .with_tags(event_tags)
                                      .with_request_uuid(RequestLocals.fetch(:dfe_analytics_request_id) { nil })
 
         DfE::Analytics::SendEvents.do([event.as_json])


### PR DESCRIPTION
An error was observed on ECF as the event tag is nil in the context of a create event. Removing the array brackets from the event tag in the entities file should prevent this - although a longer term solution will need to be found. 