### PR TITLE
Add order by clause to ensure consistent ordering

### DIFF
--- a/lib/dfe/analytics/services/generic_checksum_calculator.rb
+++ b/lib/dfe/analytics/services/generic_checksum_calculator.rb
@@ -30,15 +30,36 @@ module DfE
           checksum_calculated_at_sanitized = connection.quote(checksum_calculated_at)
           where_clause = build_where_clause(order_column, table_name_sanitized, checksum_calculated_at_sanitized)
 
+          select_clause, order_by_clause = build_select_and_order_clause(order_column, table_name_sanitized)
+
+          select_fields = "#{table_name_sanitized}.id"
+          select_fields += ", #{select_clause}" unless select_clause.empty?
+
           checksum_sql_query = <<-SQL
-            SELECT #{table_name_sanitized}.ID
+            SELECT #{select_fields}
             FROM #{table_name_sanitized}
             #{where_clause}
-            ORDER BY #{table_name_sanitized}.#{order_column} ASC
+            ORDER BY #{order_by_clause}
           SQL
 
           table_ids = connection.execute(checksum_sql_query).pluck('id')
           [table_ids.count, Digest::MD5.hexdigest(table_ids.join)]
+        end
+
+        def build_select_and_order_clause(order_column, table_name_sanitized)
+          case order_column
+          when 'updated_at'
+            select_clause = "#{table_name_sanitized}.updated_at as updated_at_alias"
+            order_by_clause = "updated_at_alias ASC, #{table_name_sanitized}.id ASC"
+          when 'created_at'
+            select_clause = "#{table_name_sanitized}.created_at as created_at_alias, "
+            order_by_clause = "created_at_alias ASC, #{table_name_sanitized}.id ASC"
+          else
+            select_clause = ''
+            order_by_clause = "#{table_name_sanitized}.id ASC"
+          end
+
+          [select_clause, order_by_clause]
         end
 
         def build_where_clause(order_column, table_name_sanitized, checksum_calculated_at_sanitized)

--- a/lib/dfe/analytics/services/generic_checksum_calculator.rb
+++ b/lib/dfe/analytics/services/generic_checksum_calculator.rb
@@ -1,4 +1,5 @@
 require_relative '../shared/service_pattern'
+require_relative '../shared/checksum_query_components'
 
 module DfE
   module Analytics
@@ -7,6 +8,7 @@ module DfE
       # and order column in a generic database
       class GenericChecksumCalculator
         include ServicePattern
+        include ChecksumQueryComponents
 
         WHERE_CLAUSE_ORDER_COLUMNS = %w[CREATED_AT UPDATED_AT].freeze
 
@@ -44,28 +46,6 @@ module DfE
 
           table_ids = connection.execute(checksum_sql_query).pluck('id')
           [table_ids.count, Digest::MD5.hexdigest(table_ids.join)]
-        end
-
-        def build_select_and_order_clause(order_column, table_name_sanitized)
-          case order_column
-          when 'updated_at'
-            select_clause = "#{table_name_sanitized}.updated_at as updated_at_alias"
-            order_by_clause = "updated_at_alias ASC, #{table_name_sanitized}.ID ASC"
-          when 'created_at'
-            select_clause = "#{table_name_sanitized}.created_at as created_at_alias"
-            order_by_clause = "created_at_alias ASC, #{table_name_sanitized}.ID ASC"
-          else
-            select_clause = ''
-            order_by_clause = "#{table_name_sanitized}.ID ASC"
-          end
-
-          [select_clause, order_by_clause]
-        end
-
-        def build_where_clause(order_column, table_name_sanitized, checksum_calculated_at_sanitized)
-          return '' unless WHERE_CLAUSE_ORDER_COLUMNS.map(&:downcase).include?(order_column.downcase)
-
-          "WHERE #{table_name_sanitized}.#{order_column.downcase} < #{checksum_calculated_at_sanitized}"
         end
       end
     end

--- a/lib/dfe/analytics/services/generic_checksum_calculator.rb
+++ b/lib/dfe/analytics/services/generic_checksum_calculator.rb
@@ -32,7 +32,7 @@ module DfE
 
           select_clause, order_by_clause = build_select_and_order_clause(order_column, table_name_sanitized)
 
-          select_fields = "#{table_name_sanitized}.id"
+          select_fields = "#{table_name_sanitized}.ID"
           select_fields += ", #{select_clause}" unless select_clause.empty?
 
           checksum_sql_query = <<-SQL
@@ -50,22 +50,22 @@ module DfE
           case order_column
           when 'updated_at'
             select_clause = "#{table_name_sanitized}.updated_at as updated_at_alias"
-            order_by_clause = "updated_at_alias ASC, #{table_name_sanitized}.id ASC"
+            order_by_clause = "updated_at_alias ASC, #{table_name_sanitized}.ID ASC"
           when 'created_at'
-            select_clause = "#{table_name_sanitized}.created_at as created_at_alias, "
-            order_by_clause = "created_at_alias ASC, #{table_name_sanitized}.id ASC"
+            select_clause = "#{table_name_sanitized}.created_at as created_at_alias"
+            order_by_clause = "created_at_alias ASC, #{table_name_sanitized}.ID ASC"
           else
             select_clause = ''
-            order_by_clause = "#{table_name_sanitized}.id ASC"
+            order_by_clause = "#{table_name_sanitized}.ID ASC"
           end
 
           [select_clause, order_by_clause]
         end
 
         def build_where_clause(order_column, table_name_sanitized, checksum_calculated_at_sanitized)
-          return '' unless WHERE_CLAUSE_ORDER_COLUMNS.include?(order_column)
+          return '' unless WHERE_CLAUSE_ORDER_COLUMNS.map(&:downcase).include?(order_column.downcase)
 
-          "WHERE #{table_name_sanitized}.#{order_column} < #{checksum_calculated_at_sanitized}"
+          "WHERE #{table_name_sanitized}.#{order_column.downcase} < #{checksum_calculated_at_sanitized}"
         end
       end
     end

--- a/lib/dfe/analytics/services/postgres_checksum_calculator.rb
+++ b/lib/dfe/analytics/services/postgres_checksum_calculator.rb
@@ -8,7 +8,7 @@ module DfE
       class PostgresChecksumCalculator
         include ServicePattern
 
-        ALLOWED_ORDER_COLUMNS = %w[CREATED_AT UPDATED_AT].freeze
+        WHERE_CLAUSE_ORDER_COLUMNS = %w[CREATED_AT UPDATED_AT].freeze
 
         def initialize(entity, order_column, checksum_calculated_at)
           @entity = entity
@@ -63,7 +63,7 @@ module DfE
         end
 
         def build_where_clause(order_column, table_name_sanitized, checksum_calculated_at_sanitized)
-          return '' unless ALLOWED_ORDER_COLUMNS.map(&:downcase).include?(order_column.downcase)
+          return '' unless WHERE_CLAUSE_ORDER_COLUMNS.map(&:downcase).include?(order_column.downcase)
 
           "WHERE #{table_name_sanitized}.#{order_column.downcase} < #{checksum_calculated_at_sanitized}"
         end

--- a/lib/dfe/analytics/services/postgres_checksum_calculator.rb
+++ b/lib/dfe/analytics/services/postgres_checksum_calculator.rb
@@ -10,8 +10,6 @@ module DfE
         include ServicePattern
         include ChecksumQueryComponents
 
-        WHERE_CLAUSE_ORDER_COLUMNS = %w[CREATED_AT UPDATED_AT].freeze
-
         def initialize(entity, order_column, checksum_calculated_at)
           @entity = entity
           @order_column = order_column
@@ -31,11 +29,11 @@ module DfE
           table_name_sanitized = connection.quote_table_name(entity)
           checksum_calculated_at_sanitized = connection.quote(checksum_calculated_at)
           where_clause = build_where_clause(order_column, table_name_sanitized, checksum_calculated_at_sanitized)
-          select_clause, order_by_clause = build_select_and_order_clause(order_column, table_name_sanitized)
+          select_clause, order_alias = build_select_and_order_clause(order_column, table_name_sanitized)
 
           checksum_sql_query = <<-SQL
           SELECT COUNT(*) as row_count,
-            MD5(COALESCE(STRING_AGG(CHECKSUM_TABLE.ID, '' ORDER BY #{order_by_clause}), '')) as checksum
+            MD5(COALESCE(STRING_AGG(CHECKSUM_TABLE.ID, '' ORDER BY CHECKSUM_TABLE.#{order_alias} ASC, CHECKSUM_TABLE.ID ASC), ''))
           FROM (
             SELECT #{table_name_sanitized}.id::TEXT as ID,
             #{select_clause}
@@ -46,6 +44,22 @@ module DfE
 
           result = connection.execute(checksum_sql_query).first
           [result['row_count'].to_i, result['checksum']]
+        end
+
+        def build_select_and_order_clause(order_column, table_name_sanitized)
+          order_alias = case order_column
+                        when 'UPDATED_AT', 'CREATED_AT'
+                          "#{order_column.downcase}_alias"
+                        else
+                          'id_alias'
+                        end
+          select_clause = case order_column
+                          when 'UPDATED_AT', 'CREATED_AT'
+                            "#{table_name_sanitized}.#{order_column.downcase} AS \"#{order_alias}\""
+                          else
+                            "#{table_name_sanitized}.id::TEXT AS \"#{order_alias}\""
+                          end
+          [select_clause, order_alias]
         end
       end
     end

--- a/lib/dfe/analytics/shared/checksum_query_components.rb
+++ b/lib/dfe/analytics/shared/checksum_query_components.rb
@@ -2,22 +2,6 @@
 module ChecksumQueryComponents
   WHERE_CLAUSE_ORDER_COLUMNS = %w[CREATED_AT UPDATED_AT].freeze
 
-  def build_select_and_order_clause(order_column, table_name_sanitized)
-    case order_column
-    when 'updated_at'
-      select_clause = "#{table_name_sanitized}.updated_at as updated_at_alias"
-      order_by_clause = "updated_at_alias ASC, #{table_name_sanitized}.ID ASC"
-    when 'created_at'
-      select_clause = "#{table_name_sanitized}.created_at as created_at_alias"
-      order_by_clause = "created_at_alias ASC, #{table_name_sanitized}.ID ASC"
-    else
-      select_clause = ''
-      order_by_clause = "#{table_name_sanitized}.ID ASC"
-    end
-
-    [select_clause, order_by_clause]
-  end
-
   def build_where_clause(order_column, table_name_sanitized, checksum_calculated_at_sanitized)
     return '' unless WHERE_CLAUSE_ORDER_COLUMNS.map(&:downcase).include?(order_column.downcase)
 

--- a/lib/dfe/analytics/shared/checksum_query_components.rb
+++ b/lib/dfe/analytics/shared/checksum_query_components.rb
@@ -1,0 +1,26 @@
+# components used by checksum calculator
+module ChecksumQueryComponents
+  WHERE_CLAUSE_ORDER_COLUMNS = %w[CREATED_AT UPDATED_AT].freeze
+
+  def build_select_and_order_clause(order_column, table_name_sanitized)
+    case order_column
+    when 'updated_at'
+      select_clause = "#{table_name_sanitized}.updated_at as updated_at_alias"
+      order_by_clause = "updated_at_alias ASC, #{table_name_sanitized}.ID ASC"
+    when 'created_at'
+      select_clause = "#{table_name_sanitized}.created_at as created_at_alias"
+      order_by_clause = "created_at_alias ASC, #{table_name_sanitized}.ID ASC"
+    else
+      select_clause = ''
+      order_by_clause = "#{table_name_sanitized}.ID ASC"
+    end
+
+    [select_clause, order_by_clause]
+  end
+
+  def build_where_clause(order_column, table_name_sanitized, checksum_calculated_at_sanitized)
+    return '' unless WHERE_CLAUSE_ORDER_COLUMNS.map(&:downcase).include?(order_column.downcase)
+
+    "WHERE #{table_name_sanitized}.#{order_column.downcase} < #{checksum_calculated_at_sanitized}"
+  end
+end

--- a/spec/dfe/analytics/services/entity_table_checks_spec.rb
+++ b/spec/dfe/analytics/services/entity_table_checks_spec.rb
@@ -140,7 +140,6 @@ RSpec.describe DfE::Analytics::Services::EntityTableChecks do
         Candidate.create(id: '125', updated_at: DateTime.parse(checksum_calculated_at) + 5.hours)
 
         table_ids = Candidate.where('updated_at < ?', checksum_calculated_at).order(:updated_at).pluck(:id)
-        table_ids = table_ids.sort
         checksum = Digest::MD5.hexdigest(table_ids.join)
 
         described_class.call(entity_name: candidate_entity, entity_type: entity_type, entity_tag: nil)


### PR DESCRIPTION
This PR attempts to fix an issue we have with periodic mismatching of checksums - which might be arising due to a lack of enforced ordering