### PR TITLE
Update rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ task :prepare_release, %i[version] do |_, args|
 
   sh 'git', 'commit', '-a', '-m', v_version
 
-  sh 'gem', 'tag'
+  sh 'git', 'tag', v_version
 
   puts <<~EOMESSAGE
     Release #{v_version} is almost ready! Before you push:


### PR DESCRIPTION
We've identified that the current annotated tagging process in the dfe-analytics release workflow is leading to complications, particularly with Dependabot's handling of our releases. 

This PR modifies our tagging strategy to create lightweight (non-annotated) tags instead. This adjustment ensures each tag is associated with a single commit hash, streamlining our version history and preventing the confusion experienced by Dependabot.