### PR TITLE
Update release instructions relating to tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,14 +499,14 @@ Please note that page caching is project specific and each project must carefull
 
 1. Merge all changes to be included in the release into the main branch and run a `git pull` on your local main branch
 2. Checkout a release branch: `git checkout -b v${NEW_VERSION}-release`, e.g. `git checkout -b v1.3.0-release`
-3. Whilst on the release branch, bump the version and generate the CHANGELOG.md. This will commit and tag changes: `rake prepare_release[minor]`
+3. Whilst on the release branch, bump the version and generate the CHANGELOG.md. `rake prepare_release[minor]`
 > **NB**: Any updated dependencies will reflect in the `Gemfile.lock`. This only affects the local dev env, and only require that specs pass
 >   It could be nice to have tests to prove that connectivity to GCP still works after an update, but we aren't setup for that yet
 4. Verify committed `CHANGELOG.md` changes and alter if necessary: `git show`
 5. Push the branch: `git push origin v${NEW_VERSION}-release`, e.g. `git push origin v1.3.0-release`
 6. Raise a version release PR on GitHub with the label `version-release`, and wait for approval
-7. Once the PR has been approved, and prior to merging, push the tags: `git push --tags`
-8. Merge the version release PR into main
+7. Merge the version release PR into main
+8. Tag the release by running `git tag v${NEW_VERSION}` followed by `git push --tags origin`
 
 IMPORTANT:  Pushing the tags will immediately make the release available even on a unmerged branch. Therefore, push the tags to Github only when the PR is approved and immediately prior to merging the PR.
 

--- a/Rakefile
+++ b/Rakefile
@@ -24,8 +24,6 @@ task :prepare_release, %i[version] do |_, args|
 
   sh 'git', 'commit', '-a', '-m', v_version
 
-  sh 'git', 'tag', v_version
-
   puts <<~EOMESSAGE
     Release #{v_version} is almost ready! Before you push:
 
@@ -36,14 +34,5 @@ task :prepare_release, %i[version] do |_, args|
 
         git show -- CHANGELOG.md
 
-    - Ensure that if you rebase or amend HEAD in any way, the #{v_version} tag
-      points to the new HEAD; the references listed here should point to the
-      same SHA:
-
-        git show-ref tags/#{v_version} heads/#{v_version}-release
-
-    Once you're happy with the CHANGELOG.md and the tag, you can push it with:
-
-      git push --tags origin
   EOMESSAGE
 end


### PR DESCRIPTION
This PR updates our release process to manually tag the release after the release PR has been merged into main. This should mean the tag references the correct commit and makes it more likely that Depandabot finds the new release without erroring.