### PR TITLE
Re-add 'as checksum'

### DIFF
--- a/lib/dfe/analytics/services/postgres_checksum_calculator.rb
+++ b/lib/dfe/analytics/services/postgres_checksum_calculator.rb
@@ -33,7 +33,7 @@ module DfE
 
           checksum_sql_query = <<-SQL
           SELECT COUNT(*) as row_count,
-            MD5(COALESCE(STRING_AGG(CHECKSUM_TABLE.ID, '' ORDER BY CHECKSUM_TABLE.#{order_alias} ASC, CHECKSUM_TABLE.ID ASC), ''))
+            MD5(COALESCE(STRING_AGG(CHECKSUM_TABLE.ID, '' ORDER BY CHECKSUM_TABLE.#{order_alias} ASC, CHECKSUM_TABLE.ID ASC), '')) as checksum
           FROM (
             SELECT #{table_name_sanitized}.id::TEXT as ID,
             #{select_clause}


### PR DESCRIPTION
In the latest re-factoring, 'as checksum' was omitted and this stopped checksums from pulling through. This PR fixes that.