### PR TITLE
Allow hidden data to be sent separately

### DIFF
--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -211,7 +211,10 @@ module DfE
       hidden_attributes = attributes.slice(*exportable_hidden_pii_attrs&.map(&:to_s))
 
       # Allowed attributes (which currently includes the allowlist_pii) must be kept separate from hidden_attributes
-      [allowed_attributes.deep_merge(obfuscated_attributes), hidden_attributes]
+      model_attributes = {}
+      model_attributes.merge!(data: allowed_attributes.deep_merge(obfuscated_attributes)) if allowed_attributes.any? || obfuscated_attributes.any?
+      model_attributes.merge!(hidden_data: hidden_attributes) if hidden_attributes.any?
+      model_attributes
     end
 
     def self.anonymise(value)

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -192,16 +192,26 @@ module DfE
     def self.extract_model_attributes(model, attributes = nil)
       # if no list of attrs specified, consider all attrs belonging to this model
       attributes ||= model.attributes
-      table_name = model.class.table_name
+      table_name = model.class.table_name.to_sym
 
-      exportable_attrs = allowlist[table_name.to_sym].presence || []
-      pii_attrs = allowlist_pii[table_name.to_sym].presence || []
+      exportable_attrs = (allowlist[table_name].presence || []).map(&:to_sym)
+      hidden_pii_attrs = (hidden_pii[table_name].presence || []).map(&:to_sym)
+      pii_attrs = (allowlist_pii[table_name].presence || []).map(&:to_sym)
+
+      # Validation in fields.rb ensures attributes do not appear on both allowlist_pii and allowlist_hidden_pii
       exportable_pii_attrs = exportable_attrs & pii_attrs
+      exportable_hidden_pii_attrs = exportable_attrs & hidden_pii_attrs
 
-      allowed_attributes = attributes.slice(*exportable_attrs&.map(&:to_s))
-      obfuscated_attributes = attributes.slice(*exportable_pii_attrs&.map(&:to_s))
+      # Exclude both pii and hidden attributes from allowed_attributes
+      allowed_attrs_to_include = exportable_attrs - (exportable_pii_attrs + exportable_hidden_pii_attrs)
 
-      allowed_attributes.deep_merge(obfuscated_attributes.transform_values { |value| pseudonymise(value) })
+      allowed_attributes = attributes.slice(*allowed_attrs_to_include&.map(&:to_s))
+      obfuscated_attributes = attributes.slice(*exportable_pii_attrs.map(&:to_s))
+                .transform_values { |value| pseudonymise(value) }
+      hidden_attributes = attributes.slice(*exportable_hidden_pii_attrs&.map(&:to_s))
+
+      # Allowed attributes (which currently includes the allowlist_pii) must be kept separate from hidden_attributes
+      [allowed_attributes.deep_merge(obfuscated_attributes), hidden_attributes]
     end
 
     def self.anonymise(value)

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -143,6 +143,8 @@ module DfE
 
     def self.hidden_pii
       Rails.application.config_for(:analytics_hidden_pii)
+    rescue RuntimeError
+      { 'shared' => {} }
     end
 
     def self.blocklist

--- a/lib/dfe/analytics/entities.rb
+++ b/lib/dfe/analytics/entities.rb
@@ -9,35 +9,33 @@ module DfE
         attr_accessor :event_tags
 
         after_create do
-          allowed_data, hidden_data = DfE::Analytics.extract_model_attributes(self)
-          send_event('create_entity', allowed_data, hidden_data) if allowed_data.any? || hidden_data.any?
+          extracted_attributes = DfE::Analytics.extract_model_attributes(self)
+          send_event('create_entity', extracted_attributes) if extracted_attributes.any?
         end
 
         after_destroy do
-          allowed_data, hidden_data = DfE::Analytics.extract_model_attributes(self)
-          send_event('delete_entity', allowed_data, hidden_data) if allowed_data.any? || hidden_data.any?
+          extracted_attributes = DfE::Analytics.extract_model_attributes(self)
+          send_event('delete_entity', extracted_attributes) if extracted_attributes.any?
         end
 
         after_update do
-          # in this after_update hook we don’t have access to the new fields via
+          # in this after_update hook we don't have access to the new fields via
           # #attributes — we need to dig them out of saved_changes which stores
           # them in the format { attr: ['old', 'new'] }
-          allowed_data, hidden_data = DfE::Analytics.extract_model_attributes(
-            self, saved_changes.transform_values(&:last)
-          )
+          new_attributes = saved_changes.transform_values(&:last)
 
-          send_event('update_entity', DfE::Analytics.extract_model_attributes(self).first.merge(allowed_data), hidden_data) if allowed_data.any? || hidden_data.any?
+          extracted_attributes = DfE::Analytics.extract_model_attributes(self, new_attributes)
+          send_event('update_entity', extracted_attributes) if extracted_attributes.any?
         end
       end
 
-      def send_event(type, allowed_data, hidden_data = {})
+      def send_event(type, data)
         return unless DfE::Analytics.enabled?
 
         event = DfE::Analytics::Event.new
                                      .with_type(type)
                                      .with_entity_table_name(self.class.table_name)
-                                     .with_data(allowed_data)
-                                     .with_hidden_data(hidden_data)
+                                     .with_data(data)
                                      .with_tags(event_tags)
                                      .with_request_uuid(RequestLocals.fetch(:dfe_analytics_request_id) { nil })
 

--- a/lib/dfe/analytics/entities.rb
+++ b/lib/dfe/analytics/entities.rb
@@ -9,34 +9,35 @@ module DfE
         attr_accessor :event_tags
 
         after_create do
-          data = DfE::Analytics.extract_model_attributes(self)
-          send_event('create_entity', data) if data.any?
+          allowed_data, hidden_data = DfE::Analytics.extract_model_attributes(self)
+          send_event('create_entity', allowed_data, hidden_data) if allowed_data.any? || hidden_data.any?
         end
 
         after_destroy do
-          data = DfE::Analytics.extract_model_attributes(self)
-          send_event('delete_entity', data) if data.any?
+          allowed_data, hidden_data = DfE::Analytics.extract_model_attributes(self)
+          send_event('delete_entity', allowed_data, hidden_data) if allowed_data.any? || hidden_data.any?
         end
 
         after_update do
           # in this after_update hook we don’t have access to the new fields via
           # #attributes — we need to dig them out of saved_changes which stores
           # them in the format { attr: ['old', 'new'] }
-          interesting_changes = DfE::Analytics.extract_model_attributes(
+          allowed_data, hidden_data = DfE::Analytics.extract_model_attributes(
             self, saved_changes.transform_values(&:last)
           )
 
-          send_event('update_entity', DfE::Analytics.extract_model_attributes(self).merge(interesting_changes)) if interesting_changes.any?
+          send_event('update_entity', DfE::Analytics.extract_model_attributes(self).first.merge(allowed_data), hidden_data) if allowed_data.any? || hidden_data.any?
         end
       end
 
-      def send_event(type, data)
+      def send_event(type, allowed_data, hidden_data = {})
         return unless DfE::Analytics.enabled?
 
         event = DfE::Analytics::Event.new
                                      .with_type(type)
                                      .with_entity_table_name(self.class.table_name)
-                                     .with_data(data)
+                                     .with_data(allowed_data)
+                                     .with_hidden_data(hidden_data)
                                      .with_tags(event_tags)
                                      .with_request_uuid(RequestLocals.fetch(:dfe_analytics_request_id) { nil })
 

--- a/lib/dfe/analytics/entities.rb
+++ b/lib/dfe/analytics/entities.rb
@@ -22,10 +22,13 @@ module DfE
           # in this after_update hook we don't have access to the new fields via
           # #attributes — we need to dig them out of saved_changes which stores
           # them in the format { attr: ['old', 'new'] }
-          new_attributes = saved_changes.transform_values(&:last)
+          updated_attributes = DfE::Analytics.extract_model_attributes(
+            self, saved_changes.transform_values(&:last)
+          )
 
-          extracted_attributes = DfE::Analytics.extract_model_attributes(self, new_attributes)
-          send_event('update_entity', extracted_attributes) if extracted_attributes.any?
+          allowed_attributes = DfE::Analytics.extract_model_attributes(self).deep_merge(updated_attributes)
+
+          send_event('update_entity', allowed_attributes) if updated_attributes.any?
         end
       end
 

--- a/lib/dfe/analytics/event.rb
+++ b/lib/dfe/analytics/event.rb
@@ -4,6 +4,7 @@ require 'active_support/values/time_zone'
 
 module DfE
   module Analytics
+    # rubocop:disable Metrics/ClassLength
     class Event
       EVENT_TYPES = %w[
         web_request create_entity update_entity delete_entity import_entity initialise_analytics entity_table_check import_entity_table_check
@@ -78,6 +79,12 @@ module DfE
         self
       end
 
+      def with_hidden_data(hash)
+        @event_hash.deep_merge!(hidden_data: hash_to_kv_pairs(hash))
+
+        self
+      end
+
       def with_tags(tags)
         @event_hash[:event_tags] = tags if tags
 
@@ -137,5 +144,6 @@ module DfE
         user_id
       end
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/dfe/analytics/event.rb
+++ b/lib/dfe/analytics/event.rb
@@ -73,8 +73,8 @@ module DfE
       end
 
       def with_data(hash)
-        @event_hash.deep_merge!(data: hash_to_kv_pairs(hash[:data]))
-        @event_hash.deep_merge!(hidden_data: hash_to_kv_pairs(hash[:hidden_data]))
+        @event_hash.deep_merge!(data: hash_to_kv_pairs(hash[:data])) if hash.include?(:data)
+        @event_hash.deep_merge!(hidden_data: hash_to_kv_pairs(hash[:hidden_data])) if hash.include?(:hidden_data)
 
         self
       end

--- a/lib/dfe/analytics/event.rb
+++ b/lib/dfe/analytics/event.rb
@@ -4,7 +4,6 @@ require 'active_support/values/time_zone'
 
 module DfE
   module Analytics
-    # rubocop:disable Metrics/ClassLength
     class Event
       EVENT_TYPES = %w[
         web_request create_entity update_entity delete_entity import_entity initialise_analytics entity_table_check import_entity_table_check
@@ -74,13 +73,8 @@ module DfE
       end
 
       def with_data(hash)
-        @event_hash.deep_merge!(data: hash_to_kv_pairs(hash))
-
-        self
-      end
-
-      def with_hidden_data(hash)
-        @event_hash.deep_merge!(hidden_data: hash_to_kv_pairs(hash))
+        @event_hash.deep_merge!(data: hash_to_kv_pairs(hash[:data]))
+        @event_hash.deep_merge!(hidden_data: hash_to_kv_pairs(hash[:hidden_data]))
 
         self
       end
@@ -116,6 +110,8 @@ module DfE
       end
 
       def hash_to_kv_pairs(hash)
+        return [] if hash.nil?
+
         hash.map do |(key, values)|
           if Array.wrap(values).any?(&:nil?)
             message = "an array field contains nulls - event: #{@event_hash} key: #{key} values: #{values}"
@@ -144,6 +140,5 @@ module DfE
         user_id
       end
     end
-    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/dfe/analytics/fields.rb
+++ b/lib/dfe/analytics/fields.rb
@@ -45,6 +45,15 @@ module DfE
           HEREDOC
         end
 
+        if overlapping_pii_fields.any?
+          errors << <<~HEREDOC
+            PII configuration error detected! The following fields are listed in both hidden_pii and allowlist_pii.
+            Fields must only be present in one. Please update the configuration to resolve the conflict:
+
+            #{overlapping_pii_fields.to_yaml}
+          HEREDOC
+        end
+
         configuration_errors = errors.join("\n\n----------------\n\n")
 
         raise(ConfigurationError, configuration_errors) if errors.any?
@@ -60,6 +69,21 @@ module DfE
 
       def self.hidden_pii
         DfE::Analytics.hidden_pii
+      end
+
+      def self.allowlist_pii
+        DfE::Analytics.allowlist_pii
+      end
+
+      def self.overlapping_pii_fields
+        overlapping_fields = []
+        hidden_pii.each do |entity, fields|
+          if allowlist_pii[entity]
+            overlapping = fields & allowlist_pii[entity]
+            overlapping_fields.concat(overlapping) unless overlapping.empty?
+          end
+        end
+        overlapping_fields
       end
 
       def self.database

--- a/lib/dfe/analytics/initialisation_events.rb
+++ b/lib/dfe/analytics/initialisation_events.rb
@@ -27,7 +27,7 @@ module DfE
 
         initialise_analytics_event = DfE::Analytics::Event.new
                                                 .with_type('initialise_analytics')
-                                                .with_data(initialise_analytics_data)
+                                                .with_data(data: initialise_analytics_data)
                                                 .as_json
 
         if DfE::Analytics.async?

--- a/lib/dfe/analytics/load_entity_batch.rb
+++ b/lib/dfe/analytics/load_entity_batch.rb
@@ -27,7 +27,6 @@ module DfE
             process_batch(model_class, ids, entity_tag)
           end
         end
-        puts 'SendEvents.perform_now called'
       end
 
       private

--- a/lib/dfe/analytics/load_entity_batch.rb
+++ b/lib/dfe/analytics/load_entity_batch.rb
@@ -4,26 +4,39 @@ module DfE
       # https://cloud.google.com/bigquery/quotas#streaming_inserts
       # at a batch size of 500, this allows 20kb per record
       BQ_BATCH_MAX_BYTES = 10_000_000
+      MIN_BATCH_SIZE = 1
 
       def perform(model_class_arg, ids, entity_tag)
+        return if ids.empty?
+
         model_class = resolve_model_class(model_class_arg)
 
-        events = create_events(model_class, ids, entity_tag)
-
-        payload_byte_size = events.sum(&:byte_size_in_transit)
-
-        # if we overrun the max batch size, recurse with each half of the list
-        if payload_byte_size > BQ_BATCH_MAX_BYTES
-          ids.each_slice((ids.size / 2.0).round).to_a.each do |half_batch|
-            Rails.logger.info "Halving batch of size #{payload_byte_size} for #{model_class.name}"
-            self.class.perform_later(model_class_arg, half_batch, entity_tag)
-          end
+        # Process the entire batch if it's small enough or if splitting is no longer feasible
+        if ids.size <= MIN_BATCH_SIZE
+          process_batch(model_class, ids, entity_tag)
         else
-          DfE::Analytics::SendEvents.perform_now(events.as_json)
+          events = create_events(model_class, ids, entity_tag)
+          payload_byte_size = events.sum(&:byte_size_in_transit)
+
+          if payload_byte_size > BQ_BATCH_MAX_BYTES
+            ids.each_slice((ids.size / 2.0).round).to_a.each do |half_batch|
+              Rails.logger.info "Halving batch of size #{payload_byte_size} for #{model_class.name}"
+              self.class.perform_later(model_class_arg, half_batch, entity_tag)
+            end
+          else
+            process_batch(model_class, ids, entity_tag)
+          end
         end
+        puts 'SendEvents.perform_now called'
       end
 
       private
+
+      def process_batch(model_class, ids, entity_tag)
+        Rails.logger.info "Processing batch for #{model_class.name} with #{ids.size} records."
+        events = create_events(model_class, ids, entity_tag)
+        DfE::Analytics::SendEvents.perform_now(events.as_json)
+      end
 
       def resolve_model_class(model_class_arg)
         # Support string args for Rails < 6.1
@@ -37,11 +50,17 @@ module DfE
       end
 
       def build_event(record, table_name, entity_tag)
-        DfE::Analytics::Event.new
-            .with_type('import_entity')
-            .with_entity_table_name(table_name)
-            .with_tags([entity_tag])
-            .with_data(DfE::Analytics.extract_model_attributes(record))
+        allowed_data, hidden_data = DfE::Analytics.extract_model_attributes(record)
+
+        event = DfE::Analytics::Event.new
+          .with_type('import_entity')
+          .with_entity_table_name(table_name)
+          .with_tags([entity_tag])
+
+        event = event.with_data(allowed_data) if allowed_data.any?
+        event = event.with_hidden_data(hidden_data) if hidden_data.any?
+
+        event
       end
     end
   end

--- a/lib/dfe/analytics/load_entity_batch.rb
+++ b/lib/dfe/analytics/load_entity_batch.rb
@@ -4,38 +4,26 @@ module DfE
       # https://cloud.google.com/bigquery/quotas#streaming_inserts
       # at a batch size of 500, this allows 20kb per record
       BQ_BATCH_MAX_BYTES = 10_000_000
-      MIN_BATCH_SIZE = 1
 
       def perform(model_class_arg, ids, entity_tag)
-        return if ids.empty?
-
         model_class = resolve_model_class(model_class_arg)
 
-        # Process the entire batch if it's small enough or if splitting is no longer feasible
-        if ids.size <= MIN_BATCH_SIZE
-          process_batch(model_class, ids, entity_tag)
-        else
-          events = create_events(model_class, ids, entity_tag)
-          payload_byte_size = events.sum(&:byte_size_in_transit)
+        events = create_events(model_class, ids, entity_tag)
 
-          if payload_byte_size > BQ_BATCH_MAX_BYTES
-            ids.each_slice((ids.size / 2.0).round).to_a.each do |half_batch|
-              Rails.logger.info "Halving batch of size #{payload_byte_size} for #{model_class.name}"
-              self.class.perform_later(model_class_arg, half_batch, entity_tag)
-            end
-          else
-            process_batch(model_class, ids, entity_tag)
+        payload_byte_size = events.sum(&:byte_size_in_transit)
+
+        # if we overrun the max batch size, recurse with each half of the list
+        if payload_byte_size > BQ_BATCH_MAX_BYTES
+          ids.each_slice((ids.size / 2.0).round).to_a.each do |half_batch|
+            Rails.logger.info "Halving batch of size #{payload_byte_size} for #{model_class.name}"
+            self.class.perform_later(model_class_arg, half_batch, entity_tag)
           end
+        else
+          DfE::Analytics::SendEvents.perform_now(events.as_json)
         end
       end
 
       private
-
-      def process_batch(model_class, ids, entity_tag)
-        Rails.logger.info "Processing batch for #{model_class.name} with #{ids.size} records."
-        events = create_events(model_class, ids, entity_tag)
-        DfE::Analytics::SendEvents.perform_now(events.as_json)
-      end
 
       def resolve_model_class(model_class_arg)
         # Support string args for Rails < 6.1
@@ -49,17 +37,11 @@ module DfE
       end
 
       def build_event(record, table_name, entity_tag)
-        allowed_data, hidden_data = DfE::Analytics.extract_model_attributes(record)
-
-        event = DfE::Analytics::Event.new
-          .with_type('import_entity')
-          .with_entity_table_name(table_name)
-          .with_tags([entity_tag])
-
-        event = event.with_data(allowed_data) if allowed_data.any?
-        event = event.with_hidden_data(hidden_data) if hidden_data.any?
-
-        event
+        DfE::Analytics::Event.new
+            .with_type('import_entity')
+            .with_entity_table_name(table_name)
+            .with_tags([entity_tag])
+            .with_data(DfE::Analytics.extract_model_attributes(record))
       end
     end
   end

--- a/lib/dfe/analytics/services/entity_table_checks.rb
+++ b/lib/dfe/analytics/services/entity_table_checks.rb
@@ -108,7 +108,7 @@ module DfE
             .with_type(entity_type)
             .with_entity_table_name(entity_name)
             .with_tags([entity_tag])
-            .with_data(entity_table_check_data(entity_name, order_column))
+            .with_data(data: entity_table_check_data(entity_name, order_column))
             .as_json
         end
       end

--- a/spec/dfe/analytics/entities_spec.rb
+++ b/spec/dfe/analytics/entities_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe DfE::Analytics::Entities do
-  let(:interesting_fields) { [] }
+  let(:allowlist_fields) { [] }
   let(:pii_fields) { [] }
   let(:hidden_pii_fields) { [] }
 
@@ -20,7 +20,7 @@ RSpec.describe DfE::Analytics::Entities do
     allow(DfE::Analytics).to receive(:enabled?).and_return(true)
 
     allow(DfE::Analytics).to receive(:allowlist).and_return({
-      Candidate.table_name.to_sym => interesting_fields
+      Candidate.table_name.to_sym => allowlist_fields
     })
 
     allow(DfE::Analytics).to receive(:allowlist_pii).and_return({
@@ -39,7 +39,7 @@ RSpec.describe DfE::Analytics::Entities do
 
   describe 'create_entity events' do
     context 'when fields are specified in the analytics file' do
-      let(:interesting_fields) { ['id'] }
+      let(:allowlist_fields) { ['id'] }
 
       it 'includes attributes specified in the settings file' do
         Candidate.create(id: 123)
@@ -91,7 +91,7 @@ RSpec.describe DfE::Analytics::Entities do
       end
 
       context 'and the specified fields are listed as PII' do
-        let(:interesting_fields) { ['email_address'] }
+        let(:allowlist_fields) { ['email_address'] }
         let(:pii_fields) { ['email_address'] }
 
         it 'hashes those fields' do
@@ -108,7 +108,7 @@ RSpec.describe DfE::Analytics::Entities do
       end
 
       context 'and other fields are listed as PII' do
-        let(:interesting_fields) { ['id'] }
+        let(:allowlist_fields) { ['id'] }
         let(:pii_fields) { ['email_address'] }
 
         it 'does not include the fields only listed as PII' do
@@ -125,7 +125,7 @@ RSpec.describe DfE::Analytics::Entities do
     end
 
     context 'when no fields are specified in the analytics file' do
-      let(:interesting_fields) { [] }
+      let(:allowlist_fields) { [] }
 
       it 'does not send create_entity events at all' do
         Candidate.create
@@ -136,7 +136,7 @@ RSpec.describe DfE::Analytics::Entities do
     end
 
     context 'when fields are specified in the analytics and hidden_pii file' do
-      let(:interesting_fields) { %w[email_address dob] }
+      let(:allowlist_fields) { %w[email_address dob] }
       let(:hidden_pii_fields) { %w[dob] }
 
       it 'sends event with separated allowed and hidden data' do
@@ -154,7 +154,7 @@ RSpec.describe DfE::Analytics::Entities do
 
   describe 'update_entity events' do
     context 'when fields are specified in the analytics file' do
-      let(:interesting_fields) { %w[email_address first_name] }
+      let(:allowlist_fields) { %w[email_address first_name] }
 
       it 'sends update events for fields we care about' do
         entity = Candidate.create(email_address: 'foo@bar.com', first_name: 'Jason')
@@ -165,8 +165,7 @@ RSpec.describe DfE::Analytics::Entities do
             'entity_table_name' => Candidate.table_name,
             'event_type' => 'update_entity',
             'data' => [
-              { 'key' => 'email_address', 'value' => ['bar@baz.com'] },
-              { 'key' => 'first_name', 'value' => ['Jason'] }
+              { 'key' => 'email_address', 'value' => ['bar@baz.com'] }
             ]
           })])
       end
@@ -195,7 +194,7 @@ RSpec.describe DfE::Analytics::Entities do
     end
 
     context 'when no fields are specified in the analytics file' do
-      let(:interesting_fields) { [] }
+      let(:allowlist_fields) { [] }
 
       it 'does not send update events at all' do
         entity = Candidate.create
@@ -210,7 +209,7 @@ RSpec.describe DfE::Analytics::Entities do
 
     context 'when fields are specified in the analytics and hidden_pii file' do
       let(:candidate) { Candidate.create(email_address: 'name@example.com', dob: '20062000') }
-      let(:interesting_fields) { %w[email_address dob] }
+      let(:allowlist_fields) { %w[email_address dob] }
       let(:hidden_pii_fields) { %w[dob] }
 
       it 'sends events with updated allowed field but without original hidden data' do
@@ -238,7 +237,7 @@ RSpec.describe DfE::Analytics::Entities do
   end
 
   describe 'delete_entity events' do
-    let(:interesting_fields) { ['email_address'] }
+    let(:allowlist_fields) { ['email_address'] }
 
     it 'sends events when objects are deleted' do
       entity = Candidate.create(email_address: 'boo@example.com')
@@ -255,7 +254,7 @@ RSpec.describe DfE::Analytics::Entities do
     end
 
     context 'when fields are specified in the analytics and hidden_pii file' do
-      let(:interesting_fields) { %w[email_address dob] }
+      let(:allowlist_fields) { %w[email_address dob] }
       let(:hidden_pii_fields) { %w[dob] }
 
       it 'sends event indicating deletion with allowed and hidden data' do

--- a/spec/dfe/analytics/entities_spec.rb
+++ b/spec/dfe/analytics/entities_spec.rb
@@ -218,8 +218,7 @@ RSpec.describe DfE::Analytics::Entities do
         expect(DfE::Analytics::SendEvents).to have_received(:perform_later)
           .with([a_hash_including({
           'event_type' => 'update_entity',
-          'data' => array_including(a_hash_including('key' => 'email_address', 'value' => ['updated@example.com'])),
-          'hidden_data' => []
+          'data' => array_including(a_hash_including('key' => 'email_address', 'value' => ['updated@example.com']))
         })])
       end
 

--- a/spec/dfe/analytics/entities_spec.rb
+++ b/spec/dfe/analytics/entities_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe DfE::Analytics::Entities do
         expect(DfE::Analytics::SendEvents).to have_received(:perform_later)
           .with([a_hash_including({
             'event_type' => 'create_entity',
-            'data' => array_including(a_hash_including('key' => 'email_address')),
+            'data' => array_including(a_hash_including('key' => 'email_address', 'value' => ['foo@bar.com'])),
             'hidden_data' => array_including(a_hash_including('key' => 'dob', 'value' => ['20062000']))
           })])
       end

--- a/spec/dfe/analytics/entities_spec.rb
+++ b/spec/dfe/analytics/entities_spec.rb
@@ -165,7 +165,8 @@ RSpec.describe DfE::Analytics::Entities do
             'entity_table_name' => Candidate.table_name,
             'event_type' => 'update_entity',
             'data' => [
-              { 'key' => 'email_address', 'value' => ['bar@baz.com'] }
+              { 'key' => 'email_address', 'value' => ['bar@baz.com'] },
+              { 'key' => 'first_name', 'value' => ['Jason'] }
             ]
           })])
       end

--- a/spec/dfe/analytics/load_entity_batch_spec.rb
+++ b/spec/dfe/analytics/load_entity_batch_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe DfE::Analytics::LoadEntityBatch do
   with_model :Candidate do
     table do |t|
       t.string :email_address
+      t.string :dob
     end
   end
 
@@ -11,7 +12,7 @@ RSpec.describe DfE::Analytics::LoadEntityBatch do
     allow(DfE::Analytics::SendEvents).to receive(:perform_now)
 
     allow(DfE::Analytics).to receive(:allowlist).and_return({
-      Candidate.table_name.to_sym => ['email_address']
+      Candidate.table_name.to_sym => %w[email_address]
     })
   end
 
@@ -47,7 +48,7 @@ RSpec.describe DfE::Analytics::LoadEntityBatch do
     it 'doesn’t split a batch unless it has to' do
       c = Candidate.create(email_address: '12345678910')
       c2 = Candidate.create(email_address: '12345678910')
-      stub_const('DfE::Analytics::LoadEntityBatch::BQ_BATCH_MAX_BYTES', 500)
+      stub_const('DfE::Analytics::LoadEntityBatch::BQ_BATCH_MAX_BYTES', 1000)
 
       described_class.perform_now('Candidate', [c.id, c2.id], entity_tag)
 
@@ -71,6 +72,54 @@ RSpec.describe DfE::Analytics::LoadEntityBatch do
         described_class.perform_now(Candidate, [c.id], entity_tag)
 
         expect(DfE::Analytics::SendEvents).to have_received(:perform_now).once
+      end
+    end
+
+    context 'when both allowed data and hidden data is present' do
+      before do
+        allow(DfE::Analytics).to receive(:allowlist).and_return({
+          Candidate.table_name.to_sym => %w[email_address dob]
+        })
+
+        allow(DfE::Analytics).to receive(:hidden_pii).and_return({
+          Candidate.table_name.to_sym => %w[dob]
+        })
+      end
+
+      it 'includes both allowed and hidden data in the event when present' do
+        candidate = Candidate.create(email_address: 'test@example.com', dob: '20062000')
+
+        described_class.new.perform(model_class, [candidate.id], entity_tag)
+
+        expect(DfE::Analytics::SendEvents).to have_received(:perform_now) do |events|
+          expect(events.first['data']).not_to be_empty
+          expect(events.first['hidden_data']).not_to be_empty
+        end
+      end
+
+      it 'splits a batch when the batch is too big, including hidden data' do
+        perform_enqueued_jobs do
+          c = Candidate.create(email_address: '12345678910', dob: '12072000')
+          c2 = Candidate.create(email_address: '12345678910', dob: '12072000')
+
+          stub_const('DfE::Analytics::LoadEntityBatch::BQ_BATCH_MAX_BYTES', 250)
+
+          described_class.perform_now('Candidate', [c.id, c2.id], entity_tag)
+
+          expect(DfE::Analytics::SendEvents).to have_received(:perform_now).twice
+        end
+      end
+
+      it 'does not split a batch if the payload size is below the threshold' do
+        perform_enqueued_jobs do
+          c = Candidate.create(email_address: '12345678910')
+          c2 = Candidate.create(email_address: '12345678910')
+          stub_const('DfE::Analytics::LoadEntityBatch::BQ_BATCH_MAX_BYTES', 1000)
+
+          described_class.perform_now('Candidate', [c.id, c2.id], entity_tag)
+
+          expect(DfE::Analytics::SendEvents).to have_received(:perform_now).once
+        end
       end
     end
   end

--- a/spec/dfe/analytics/load_entity_batch_spec.rb
+++ b/spec/dfe/analytics/load_entity_batch_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe DfE::Analytics::LoadEntityBatch do
       perform_enqueued_jobs do
         c = Candidate.create(email_address: '12345678910')
         c2 = Candidate.create(email_address: '12345678910')
-        stub_const('DfE::Analytics::LoadEntityBatch::BQ_BATCH_MAX_BYTES', 250)
+        stub_const('DfE::Analytics::LoadEntityBatch::BQ_BATCH_MAX_BYTES', 300)
 
         described_class.perform_now('Candidate', [c.id, c2.id], entity_tag)
 
@@ -48,7 +48,7 @@ RSpec.describe DfE::Analytics::LoadEntityBatch do
     it 'doesn’t split a batch unless it has to' do
       c = Candidate.create(email_address: '12345678910')
       c2 = Candidate.create(email_address: '12345678910')
-      stub_const('DfE::Analytics::LoadEntityBatch::BQ_BATCH_MAX_BYTES', 1000)
+      stub_const('DfE::Analytics::LoadEntityBatch::BQ_BATCH_MAX_BYTES', 550)
 
       described_class.perform_now('Candidate', [c.id, c2.id], entity_tag)
 
@@ -102,7 +102,7 @@ RSpec.describe DfE::Analytics::LoadEntityBatch do
           c = Candidate.create(email_address: '12345678910', dob: '12072000')
           c2 = Candidate.create(email_address: '12345678910', dob: '12072000')
 
-          stub_const('DfE::Analytics::LoadEntityBatch::BQ_BATCH_MAX_BYTES', 250)
+          stub_const('DfE::Analytics::LoadEntityBatch::BQ_BATCH_MAX_BYTES', 300)
 
           described_class.perform_now('Candidate', [c.id, c2.id], entity_tag)
 

--- a/spec/dfe/analytics_spec.rb
+++ b/spec/dfe/analytics_spec.rb
@@ -185,6 +185,61 @@ RSpec.describe DfE::Analytics do
     end
   end
 
+  describe '.extract_model_attributes' do
+    with_model :Candidate do
+      table do |t|
+        t.string :email_address
+        t.string :hidden_data
+        t.integer :age
+      end
+    end
+
+    before do
+      allow(DfE::Analytics).to receive(:allowlist).and_return({
+        Candidate.table_name.to_sym => %w[email_address hidden_data age]
+      })
+      allow(DfE::Analytics).to receive(:allowlist_pii).and_return({
+        Candidate.table_name.to_sym => %w[email_address]
+      })
+      allow(DfE::Analytics).to receive(:hidden_pii).and_return({
+        Candidate.table_name.to_sym => %w[hidden_data age]
+      })
+    end
+
+    let(:candidate) { Candidate.create(email_address: 'test@example.com', hidden_data: 'secret', age: 50) }
+
+    it 'correctly separates and obfuscates attributes' do
+      allowed_data, hidden_data = described_class.extract_model_attributes(candidate)
+
+      expect(allowed_data.keys).to include('email_address')
+      expect(hidden_data.keys).to include('hidden_data')
+      expect(hidden_data.keys).to include('age')
+
+      expect(allowed_data['email_address']).to_not eq(candidate.email_address)
+      expect(hidden_data['hidden_data']).to eq('secret')
+    end
+
+    it 'correctly separates allowed and hidden attributes' do
+      allowed_data, hidden_data = described_class.extract_model_attributes(candidate)
+
+      expect(allowed_data).not_to have_key('hidden_data')
+      expect(allowed_data).not_to have_key('age')
+
+      expect(hidden_data['hidden_data']).to eq('secret')
+      expect(hidden_data['age']).to eq(50)
+    end
+
+    it 'does not error if no hidden data is sent' do
+      candidate = Candidate.create(email_address: 'test@example.com')
+      allow(DfE::Analytics).to receive(:allowlist).and_return(Candidate.table_name.to_sym => %w[email_address])
+      allowed_data, hidden_data = described_class.extract_model_attributes(candidate)
+
+      expect(allowed_data.keys).to include('email_address')
+      expect(hidden_data).to be_empty
+      expect { DfE::Analytics.extract_model_attributes(candidate) }.not_to raise_error
+    end
+  end
+
   describe '.parse_maintenance_window' do
     context 'with a valid maintenance window' do
       before do

--- a/spec/dfe/analytics_spec.rb
+++ b/spec/dfe/analytics_spec.rb
@@ -209,33 +209,33 @@ RSpec.describe DfE::Analytics do
     let(:candidate) { Candidate.create(email_address: 'test@example.com', hidden_data: 'secret', age: 50) }
 
     it 'correctly separates and obfuscates attributes' do
-      allowed_data, hidden_data = described_class.extract_model_attributes(candidate)
+      result = described_class.extract_model_attributes(candidate)
 
-      expect(allowed_data.keys).to include('email_address')
-      expect(hidden_data.keys).to include('hidden_data')
-      expect(hidden_data.keys).to include('age')
+      expect(result[:data].keys).to include('email_address')
+      expect(result[:data]['email_address']).to_not eq(candidate.email_address)
 
-      expect(allowed_data['email_address']).to_not eq(candidate.email_address)
-      expect(hidden_data['hidden_data']).to eq('secret')
+      expect(result[:hidden_data]['hidden_data']).to eq('secret')
+      expect(result[:hidden_data]['age']).to eq(50)
     end
 
     it 'correctly separates allowed and hidden attributes' do
-      allowed_data, hidden_data = described_class.extract_model_attributes(candidate)
+      result = described_class.extract_model_attributes(candidate)
 
-      expect(allowed_data).not_to have_key('hidden_data')
-      expect(allowed_data).not_to have_key('age')
+      expect(result[:data].keys).to include('email_address')
+      expect(result[:data]).not_to have_key('hidden_data')
+      expect(result[:data]).not_to have_key('age')
 
-      expect(hidden_data['hidden_data']).to eq('secret')
-      expect(hidden_data['age']).to eq(50)
+      expect(result[:hidden_data]['hidden_data']).to eq('secret')
+      expect(result[:hidden_data]['age']).to eq(50)
     end
 
     it 'does not error if no hidden data is sent' do
       candidate = Candidate.create(email_address: 'test@example.com')
       allow(DfE::Analytics).to receive(:allowlist).and_return(Candidate.table_name.to_sym => %w[email_address])
-      allowed_data, hidden_data = described_class.extract_model_attributes(candidate)
 
-      expect(allowed_data.keys).to include('email_address')
-      expect(hidden_data).to be_empty
+      result = described_class.extract_model_attributes(candidate)
+      expect(result[:data].keys).to include('email_address')
+      expect(result[:hidden_data]).to be_nil.or be_empty
       expect { DfE::Analytics.extract_model_attributes(candidate) }.not_to raise_error
     end
   end


### PR DESCRIPTION
[Ticket](https://trello.com/c/IpCySdeH/1879-populate-datahidden-field-in-streamed-events) 

This PR introduces a with_hidden_data event field
Hidden data is kept separate to both allowed_data and allowed_pii
