### PR TITLE
v1.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,23 @@
 # Changelog
 
-## [v1.12.3](https://github.com/DFE-Digital/dfe-analytics/tree/v1.12.3) (2024-04-02)
+## [v1.12.4](https://github.com/DFE-Digital/dfe-analytics/tree/v1.12.4) (2024-04-24)
+
+[Full Changelog](https://github.com/DFE-Digital/dfe-analytics/compare/v1.12.3...v1.12.4)
+
+**Merged pull requests:**
+
+- Fix for flakey tests [\#134](https://github.com/DFE-Digital/dfe-analytics/pull/134) ([ericaporter](https://github.com/ericaporter))
+- Explicitly truncate updated\_at and created\_at [\#132](https://github.com/DFE-Digital/dfe-analytics/pull/132) ([ericaporter](https://github.com/ericaporter))
+- Add ImportEntityTableCheck to import task [\#131](https://github.com/DFE-Digital/dfe-analytics/pull/131) ([ericaporter](https://github.com/ericaporter))
+- Add flags to prevent code running in envs where dfe-analytics isn't set up [\#130](https://github.com/DFE-Digital/dfe-analytics/pull/130) ([ericaporter](https://github.com/ericaporter))
+
+## [v1.12.3](https://github.com/DFE-Digital/dfe-analytics/tree/v1.12.3) (2024-04-04)
 
 [Full Changelog](https://github.com/DFE-Digital/dfe-analytics/compare/v1.12.2...v1.12.3)
 
 **Merged pull requests:**
 
+- v1.12.3 [\#127](https://github.com/DFE-Digital/dfe-analytics/pull/127) ([ericaporter](https://github.com/ericaporter))
 - Re-add 'as checksum' [\#126](https://github.com/DFE-Digital/dfe-analytics/pull/126) ([ericaporter](https://github.com/ericaporter))
 - Update release instructions relating to tagging [\#124](https://github.com/DFE-Digital/dfe-analytics/pull/124) ([ericaporter](https://github.com/ericaporter))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dfe-analytics (1.12.3)
+    dfe-analytics (1.12.4)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 

--- a/lib/dfe/analytics/version.rb
+++ b/lib/dfe/analytics/version.rb
@@ -2,6 +2,6 @@
 
 module DfE
   module Analytics
-    VERSION = '1.12.3'
+    VERSION = '1.12.4'
   end
 end


### PR DESCRIPTION
- Fix for flakey tests [\#134](https://github.com/DFE-Digital/dfe-analytics/pull/134) ([ericaporter](https://github.com/ericaporter))
- Explicitly truncate updated\_at and created\_at [\#132](https://github.com/DFE-Digital/dfe-analytics/pull/132) ([ericaporter](https://github.com/ericaporter))
- Add ImportEntityTableCheck to import task [\#131](https://github.com/DFE-Digital/dfe-analytics/pull/131) ([ericaporter](https://github.com/ericaporter))
- Add flags to prevent code running in envs where dfe-analytics isn't set up [\#130](https://github.com/DFE-Digital/dfe-analytics/pull/130) ([ericaporter](https://github.com/ericaporter))