### PR TITLE
Fix for service pattern name spacing issue

### DIFF
--- a/lib/dfe/analytics/shared/service_pattern.rb
+++ b/lib/dfe/analytics/shared/service_pattern.rb
@@ -1,23 +1,27 @@
-# a template for creating service objects
-module ServicePattern
-  def self.included(base)
-    base.extend(ClassMethods)
-    base.class_eval do
-      private_class_method(:new)
-    end
-  end
+module DfE
+  module Analytics
+    # a template for creating service objects
+    module ServicePattern
+      def self.included(base)
+        base.extend(ClassMethods)
+        base.class_eval do
+          private_class_method(:new)
+        end
+      end
 
-  def call
-    raise(NotImplementedError('#call must be implemented'))
-  end
+      def call
+        raise(NotImplementedError('#call must be implemented'))
+      end
 
-  # provides class-level methods to the classes that include ServicePattern
-  # defines a template for the `call` method; the expected entry point for service objects
-  module ClassMethods
-    def call(*args, **keyword_args, &block)
-      return new.call if args.empty? && keyword_args.empty? && block.nil?
+      # provides class-level methods to the classes that include ServicePattern
+      # defines a template for the `call` method; the expected entry point for service objects
+      module ClassMethods
+        def call(*args, **keyword_args, &block)
+          return new.call if args.empty? && keyword_args.empty? && block.nil?
 
-      new(*args, **keyword_args, &block).call
+          new(*args, **keyword_args, &block).call
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
A reported issue by itt-mentor-services where our service pattern module was causing a conflict with their service pattern in their application https://github.com/DFE-Digital/dfe-analytics/issues/136

Adding in DfE::Analytics name-spacing into our service pattern module file is the likely fix.