### PR TITLE
Fix sending of initialisation events to respect maintenance window

### DIFF
--- a/lib/dfe/analytics/initialisation_events.rb
+++ b/lib/dfe/analytics/initialisation_events.rb
@@ -30,11 +30,7 @@ module DfE
                                                 .with_data(initialise_analytics_data)
                                                 .as_json
 
-        if DfE::Analytics.async?
-          DfE::Analytics::SendEvents.perform_later([initialise_analytics_event])
-        else
-          DfE::Analytics::SendEvents.perform_now([initialise_analytics_event])
-        end
+        DfE::Analytics::SendEvents.perform_for([initialise_analytics_event])
 
         @@initialisation_events_sent = true # rubocop:disable Style:ClassVars
       end

--- a/lib/dfe/analytics/send_events.rb
+++ b/lib/dfe/analytics/send_events.rb
@@ -14,6 +14,10 @@ module DfE
 
         events = events.map { |event| event.is_a?(Event) ? event.as_json : event }
 
+        perform_for(events)
+      end
+
+      def self.perform_for(events)
         if DfE::Analytics.within_maintenance_window?
           set(wait_until: DfE::Analytics.next_scheduled_time_after_maintenance_window).perform_later(events)
         elsif DfE::Analytics.async?


### PR DESCRIPTION
Fix the initialise event scheduling during the maintenance window. 

See trello ticket [here](https://trello.com/c/OLgfjgl9/1571-bq-assurance-bq-2-ensure-bigquery-tables-are-encrypted-with-customer-managed-encryption-key-cmek?filter=member:amaratwal1).