### PR TITLE
Cover edge cases for validations

### DIFF
--- a/lib/dfe/analytics/fields.rb
+++ b/lib/dfe/analytics/fields.rb
@@ -78,11 +78,11 @@ module DfE
       def self.overlapping_pii_fields
         overlapping_fields = []
         hidden_pii.each do |entity, fields|
-          next if fields.nil? || fields.empty?
+          next if fields.blank?
 
           if allowlist_pii[entity]
             overlapping = fields & allowlist_pii[entity]
-            overlapping_fields.concat(overlapping) unless overlapping.empty?
+            overlapping_fields.concat(overlapping) unless overlapping.blank?
           end
         end
         overlapping_fields

--- a/lib/dfe/analytics/fields.rb
+++ b/lib/dfe/analytics/fields.rb
@@ -68,16 +68,18 @@ module DfE
       end
 
       def self.hidden_pii
-        DfE::Analytics.hidden_pii
+        DfE::Analytics.hidden_pii || {}
       end
 
       def self.allowlist_pii
-        DfE::Analytics.allowlist_pii
+        DfE::Analytics.allowlist_pii || {}
       end
 
       def self.overlapping_pii_fields
         overlapping_fields = []
         hidden_pii.each do |entity, fields|
+          next if fields.nil? || fields.empty?
+
           if allowlist_pii[entity]
             overlapping = fields & allowlist_pii[entity]
             overlapping_fields.concat(overlapping) unless overlapping.empty?


### PR DESCRIPTION
When testing the validation that hidden_pii fields do not overlap analytics_pii fields I noticed that the validation method would error if either the allowlist_pii file were in any of these scenarios:

1. `shared:`
2. `shared: candidates:`
3. `shared: candidates: []`

rather than `shared: {}` which is explicitly empty. To avoid this I updated the following methods to:
```
def self.hidden_pii
         DfE::Analytics.hidden_pii || {}
  end

def self.allowlist_pii
      DfE::Analytics.allowlist_pii || {}
end
```

and added in `next if fields.nil? || fields.empty?` to the overlap validation method

