### PR TITLE
Fix import_all_entities rake task output

### DIFF
--- a/lib/dfe/analytics/tasks/import_entities.rake
+++ b/lib/dfe/analytics/tasks/import_entities.rake
@@ -2,9 +2,10 @@ namespace :dfe do
   namespace :analytics do
     desc 'Send Analytics events for the (allowlisted) state of all records in the database'
     task :import_all_entities, %i[batch_size] => :environment do |_, args|
-      return unless DfE::Analytics.enabled?
-
-      puts 'DfE Analytics is not enabled - Ignoring import_all_entities'
+      unless DfE::Analytics.enabled?
+        puts 'DfE Analytics is not enabled - Ignoring import_all_entities'
+        return
+      end
 
       entity_tag = Time.now.strftime('%Y%m%d%H%M%S')
       DfE::Analytics.entities_for_analytics.each do |entity_name|
@@ -15,9 +16,10 @@ namespace :dfe do
 
     desc 'Send Analytics events for the state of all records in a specified model'
     task :import_entity, %i[entity_name batch_size] => :environment do |_, args|
-      return unless DfE::Analytics.enabled?
-
-      puts 'DfE Analytics is not enabled - Ignoring import_entity'
+      unless DfE::Analytics.enabled?
+        puts 'DfE Analytics is not enabled - Ignoring import_all_entities'
+        return
+      end
 
       abort('You need to specify a model name as an argument to the Rake task, eg dfe:analytics:import_entity[Model]') unless args[:entity_name]
       entity_tag = Time.now.strftime('%Y%m%d%H%M%S')


### PR DESCRIPTION
When `enable_analytics` is `true` the `import_all_entities` rake task outputs a confusing message stating that it is not enabled, but nonetheless continues to perform the task:

```bash
$ bundle exec rails dfe:analytics:import_all_entities
DfE Analytics is not enabled - Ignoring import_all_entities
```

This fix should avoid some confusion for users! :)