### PR TITLE
Update log masking method

### DIFF
--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -172,18 +172,6 @@ module DfE
       event_debug_filters[:event_filters]&.any?
     end
 
-    def self.mask_hidden_data(event, entity_table_name)
-      return event if entity_table_name.nil?
-
-      hidden_pii_fields = hidden_pii[entity_table_name.to_sym] || []
-
-      hidden_pii_fields.each do |field|
-        event[field] = '[HIDDEN]' if event.key?(field)
-      end
-
-      event
-    end
-
     def self.async?
       config.async
     end

--- a/lib/dfe/analytics/event.rb
+++ b/lib/dfe/analytics/event.rb
@@ -18,9 +18,7 @@ module DfE
         }
       end
 
-      def event_hash
-        @event_hash
-      end
+      attr_reader :event_hash
 
       def as_json
         @event_hash.as_json

--- a/lib/dfe/analytics/event.rb
+++ b/lib/dfe/analytics/event.rb
@@ -18,8 +18,6 @@ module DfE
         }
       end
 
-      attr_reader :event_hash
-
       def as_json
         @event_hash.as_json
       end

--- a/lib/dfe/analytics/event.rb
+++ b/lib/dfe/analytics/event.rb
@@ -18,6 +18,10 @@ module DfE
         }
       end
 
+      def event_hash
+        @event_hash
+      end
+
       def as_json
         @event_hash.as_json
       end

--- a/lib/dfe/analytics/event_matcher.rb
+++ b/lib/dfe/analytics/event_matcher.rb
@@ -4,7 +4,8 @@ module DfE
     class EventMatcher
       attr_reader :event, :filters
 
-      def initialize(event, filters = DfE::Analytics.event_debug_filters[:event_filters])
+      def initialize(event, filters = nil)
+        filters ||= DfE::Analytics.event_debug_filters[:event_filters]
         raise 'Event filters must be set' if filters.nil?
 
         @event = event.with_indifferent_access
@@ -42,14 +43,18 @@ module DfE
           return false
         end
 
-        filter_value = filter_value.to_s
-        event_value = event_value.to_s
+        # Log the original values before converting to strings
+        Rails.logger.debug("Original filter_value: #{filter_value.inspect}, Original event_value: #{event_value.inspect}")
+
+        # Convert values to strings for comparison
+        filter_value_str = filter_value.to_s
+        event_value_str = event_value.to_s
 
         begin
-          regexp = Regexp.new(filter_value)
-          regexp.match?(event_value)
+          regexp = Regexp.new(filter_value_str)
+          regexp.match?(event_value_str)
         rescue StandardError => e
-          Rails.logger.error("Error in EventMatcher#field_matched?: #{e.message}. event_value: #{event_value.inspect}, filter_value: #{filter_value.inspect}, nested_fields: #{nested_fields.inspect}")
+          Rails.logger.error("Error in EventMatcher#field_matched?: #{e.message}. original event_value: #{event_value.inspect}, original filter_value: #{filter_value.inspect}, nested_fields: #{nested_fields.inspect}")
           false
         end
       end

--- a/lib/dfe/analytics/event_matcher.rb
+++ b/lib/dfe/analytics/event_matcher.rb
@@ -2,16 +2,13 @@ module DfE
   module Analytics
     # Match event against given filters
     class EventMatcher
-      attr_reader :event, :filters, :mask_hidden_data
+      attr_reader :event, :filters
 
-      def initialize(event, filters = DfE::Analytics.event_debug_filters[:event_filters], mask_hidden_data: true)
+      def initialize(event, filters = DfE::Analytics.event_debug_filters[:event_filters])
         raise 'Event filters must be set' if filters.nil?
 
         @event = event.with_indifferent_access
         @filters = filters.compact
-        @mask_hidden_data = mask_hidden_data
-
-        mask_hidden_data! if mask_hidden_data
       end
 
       def matched?
@@ -51,12 +48,6 @@ module DfE
 
           memo[field]
         end
-      end
-
-      def mask_hidden_data!
-        return unless mask_hidden_data && @event[:data] && @event[:entity_table_name]
-
-        @event[:data] = DfE::Analytics.mask_hidden_data(@event[:data], @event[:entity_table_name])
       end
     end
   end

--- a/lib/dfe/analytics/event_matcher.rb
+++ b/lib/dfe/analytics/event_matcher.rb
@@ -47,7 +47,7 @@ module DfE
           break memo.to_s unless memo.is_a?(Hash)
 
           memo[field]
-        end
+        end.to_s
       end
     end
   end

--- a/lib/dfe/analytics/event_matcher.rb
+++ b/lib/dfe/analytics/event_matcher.rb
@@ -25,6 +25,10 @@ module DfE
             # Recurse for nested hashes
             filter_matched?(filter_value, fields)
           else
+            if filter_value.nil?
+              Rails.logger.error("Nil filter value encountered. filter_value: #{filter_value.inspect}, nested_fields: #{fields.inspect}")
+              return false
+            end
             field_matched?(filter_value, fields)
           end
         end
@@ -33,8 +37,8 @@ module DfE
       def field_matched?(filter_value, nested_fields)
         event_value = event_value_for(nested_fields)
 
-        if event_value.nil? || filter_value.nil?
-          Rails.logger.error("Nil value encountered. event_value: #{event_value.inspect}, filter_value: #{filter_value.inspect}, nested_fields: #{nested_fields.inspect}")
+        if event_value.nil?
+          Rails.logger.error("Nil event value encountered. event_value: #{event_value.inspect}, nested_fields: #{nested_fields.inspect}")
           return false
         end
 

--- a/lib/dfe/analytics/event_matcher.rb
+++ b/lib/dfe/analytics/event_matcher.rb
@@ -4,9 +4,7 @@ module DfE
     class EventMatcher
       attr_reader :event, :filters
 
-      def initialize(event, filters = nil)
-        filters ||= DfE::Analytics.event_debug_filters[:event_filters]
-
+      def initialize(event, filters = DfE::Analytics.event_debug_filters[:event_filters])
         @event = event.with_indifferent_access
         @filters = filters.compact
       end

--- a/lib/dfe/analytics/event_matcher.rb
+++ b/lib/dfe/analytics/event_matcher.rb
@@ -42,10 +42,13 @@ module DfE
           return false
         end
 
+        filter_value = filter_value.to_s
+        event_value = event_value.to_s
+
         begin
           regexp = Regexp.new(filter_value)
           regexp.match?(event_value)
-        rescue => e
+        rescue StandardError => e
           Rails.logger.error("Error in EventMatcher#field_matched?: #{e.message}. event_value: #{event_value.inspect}, filter_value: #{filter_value.inspect}, nested_fields: #{nested_fields.inspect}")
           false
         end
@@ -56,7 +59,7 @@ module DfE
           break memo.to_s unless memo.is_a?(Hash)
 
           memo[field]
-        end.to_s
+        end
       end
     end
   end

--- a/lib/dfe/analytics/event_matcher.rb
+++ b/lib/dfe/analytics/event_matcher.rb
@@ -31,10 +31,14 @@ module DfE
       end
 
       def field_matched?(filter_value, nested_fields)
-        event_value = event_value_for(nested_fields)
-
-        regexp = Regexp.new(filter_value)
-
+        event_value = event_value_for(nested_fields) || ''
+      
+        begin
+          regexp = Regexp.new(filter_value)
+        rescue RegexpError
+          return false
+        end
+      
         regexp.match?(event_value)
       end
 

--- a/lib/dfe/analytics/send_events.rb
+++ b/lib/dfe/analytics/send_events.rb
@@ -21,7 +21,7 @@ module DfE
         else
           perform_now(events)
         end
-      rescue => e
+      rescue StandardError => e
         Rails.logger.error("Error in SendEvents.do: #{e.message}")
         raise e
       end
@@ -39,7 +39,7 @@ module DfE
 
           DfE::Analytics.config.azure_federated_auth ? DfE::Analytics::BigQueryApi.insert(events) : DfE::Analytics::BigQueryLegacyApi.insert(events)
         end
-      rescue => e
+      rescue StandardError => e
         Rails.logger.error("Error in SendEvents#perform: #{e.message}")
         raise e
       end
@@ -79,7 +79,7 @@ module DfE
 
         Rails.logger.info("Masked event: #{masked_event.inspect}")
         masked_event
-      rescue => e
+      rescue StandardError => e
         Rails.logger.error("Error in SendEvents#mask_hidden_data: #{e.message}")
         Rails.logger.error("Event causing error: #{event.inspect}")
         raise e

--- a/lib/dfe/analytics/send_events.rb
+++ b/lib/dfe/analytics/send_events.rb
@@ -41,24 +41,10 @@ module DfE
       private
 
       def mask_hidden_data(event)
-        masked_event = duplicate_event(event)
+        masked_event = event.deep_dup.with_indifferent_access
         return event unless masked_event&.key?(:hidden_data)
 
         mask_hidden_data_values(masked_event)
-      end
-
-      def duplicate_event(event)
-        Rails.logger.error("Event class: #{event.class}")
-
-        case event
-        when DfE::Analytics::Event
-          event.event_hash.deep_dup.with_indifferent_access
-        when Hash
-          event.deep_dup.with_indifferent_access
-        else
-          Rails.logger.error("Unsupported event type: #{event.class}")
-          nil
-        end
       end
 
       def mask_hidden_data_values(event)
@@ -70,25 +56,13 @@ module DfE
       end
 
       def mask_data(data)
-        Rails.logger.error("Data class: #{data.class}")
-
         return unless data.is_a?(Hash)
 
-        Rails.logger.error("Data contains value: #{data[:value]}") if data.key?(:value)
         data[:value] = ['HIDDEN'] if data[:value].present?
 
-        unless data.key?(:key)
-          Rails.logger.error('Data does not contain key')
-          return
-        end
+        return unless data[:key].is_a?(Hash) && data[:key][:value].present?
 
-        unless data[:key].is_a?(Hash)
-          Rails.logger.error("Data[:key] is not a Hash: #{data[:key].class}")
-          return
-        end
-
-        Rails.logger.error("Data[:key] contains value: #{data[:key][:value]}") if data[:key].key?(:value)
-        data[:key][:value] = ['HIDDEN'] if data[:key][:value].present?
+        data[:key][:value] = ['HIDDEN']
       end
     end
   end

--- a/lib/dfe/analytics/send_events.rb
+++ b/lib/dfe/analytics/send_events.rb
@@ -41,12 +41,22 @@ module DfE
       private
 
       def mask_hidden_data(event)
-        masked_event = event.deep_dup
+        if event.is_a?(DfE::Analytics::Event)
+          masked_event = event.event_hash.deep_dup
+        elsif event.is_a?(Hash)
+          masked_event = event.deep_dup
+        else
+          Rails.logger.info('Invalid input type for mask_hidden_data. Expected DfE::Analytics::Event or Hash.')
+        end
+      
         if masked_event['hidden_data'].is_a?(Array)
           masked_event['hidden_data'].each do |data|
-            data['value'] = ['HIDDEN'] if data.is_a?(Hash) && data['value']
+            if data.is_a?(Hash) && data['value']
+              data['value'] = ['HIDDEN']
+            end
           end
         end
+      
         masked_event
       end
     end

--- a/spec/dfe/analytics/event_matcher_spec.rb
+++ b/spec/dfe/analytics/event_matcher_spec.rb
@@ -127,5 +127,26 @@ RSpec.describe DfE::Analytics::EventMatcher do
         end
       end
     end
+
+    describe '.field_matched?' do
+      let(:logging) do
+        {
+          event_filters: [
+            {
+              event_type: 'update_entity',
+              entity_table_name: 'course_options',
+              data: {
+                key: 'course_id'
+              }
+            }
+          ]
+        }
+      end
+
+      it 'returns false when event_value is nil' do
+        allow(subject).to receive(:event_value_for).and_return(nil)
+        expect(subject.send(:field_matched?, 'course_id', 'data')).to be false
+      end
+    end
   end
 end

--- a/spec/dfe/analytics/send_events_spec.rb
+++ b/spec/dfe/analytics/send_events_spec.rb
@@ -150,10 +150,10 @@ RSpec.describe DfE::Analytics::SendEvents do
           }
         end
 
-        it 'logs the event' do
-          expect(Rails.logger).to receive(:info).with("DfE::Analytics processing: #{event.as_json}")
-          perform
-        end
+        # it 'logs the event' do
+        #   expect(Rails.logger).to receive(:info).with("DfE::Analytics processing: #{event.as_json}")
+        #   perform
+        # end
       end
 
       context 'when the event filter does not match' do

--- a/spec/dfe/analytics/send_events_spec.rb
+++ b/spec/dfe/analytics/send_events_spec.rb
@@ -150,10 +150,10 @@ RSpec.describe DfE::Analytics::SendEvents do
           }
         end
 
-        # it 'logs the event' do
-        #   expect(Rails.logger).to receive(:info).with("DfE::Analytics processing: #{event.as_json}")
-        #   perform
-        # end
+        it 'logs the event' do
+          expect(Rails.logger).to receive(:info).with("DfE::Analytics processing: #{event.as_json}")
+          perform
+        end
       end
 
       context 'when the event filter does not match' do


### PR DESCRIPTION
This PR includes updates to the masking hidden_pii strategy

1. It removes masking_hidden_data method from the event_matcher as this isn't necessary for masking the logs
2. Updates the masking method, so instead of finding the hidden_pii fields per entity, it now just searches for the hidden_pii key/values in the logs
3. Updates to filter_matched? method to avoid exceptions