### PR TITLE
Add big_query_api requires to testing.rb

### DIFF
--- a/lib/dfe/analytics/testing.rb
+++ b/lib/dfe/analytics/testing.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'dfe/analytics/big_query_api'
+require 'dfe/analytics/big_query_legacy_api'
+
 module DfE
   module Analytics
     module Testing


### PR DESCRIPTION
Schools experience were seeing an error when running the test suite after upgrading to the latest version of dfe-analytics.

This addition should prevent other services from seeing the same error.