### PR TITLE
Allow certain paths or endpoints to be excluded

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ DfE::Analytics.configure do |config|
   # other configurations...
 
   # Specify paths to skip
-  config.skip_web_requests = ['/healthcheck', %r{^/admin}, %r{/api/v1/status}]
+  config.excluded_paths = ['/healthcheck', %r{^/admin}, %r{/api/v1/status}]
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,17 @@ user identifier proc can be defined in `config/initializers/dfe_analytics.rb`:
 DfE::Analytics.config.user_identifier = proc { |user| user&.uid }
 ```
 
+You can specify paths that should be excluded from logging using the skip_web_requests configuration option. This is useful for endpoints like health checks that are frequently hit and do not need to be logged.
+
+```ruby
+DfE::Analytics.configure do |config|
+  # other configurations...
+
+  # Specify paths to skip
+  config.skip_web_requests = ['/healthcheck', %r{^/admin}, %r{/api/v1/status}]
+end
+```
+
 ### 6. Import existing data
 
 To load the current contents of your database into BigQuery, run

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -57,6 +57,7 @@ module DfE
         azure_scope
         gcp_scope
         google_cloud_credentials
+        excluded_paths
       ]
 
       @config ||= Struct.new(*configurables).new
@@ -82,6 +83,7 @@ module DfE
       config.rack_page_cached                 ||= proc { |_rack_env| false }
       config.bigquery_maintenance_window      ||= ENV.fetch('BIGQUERY_MAINTENANCE_WINDOW', nil)
       config.azure_federated_auth             ||= false
+      config.excluded_paths                   ||= []
 
       return unless config.azure_federated_auth
 

--- a/lib/dfe/analytics/requests.rb
+++ b/lib/dfe/analytics/requests.rb
@@ -11,6 +11,7 @@ module DfE
 
       def trigger_request_event
         return unless DfE::Analytics.enabled?
+        return if path_excluded?
 
         request_event = DfE::Analytics::Event.new
                                              .with_type('web_request')
@@ -22,6 +23,19 @@ module DfE
         request_event.with_namespace(current_namespace) if respond_to?(:current_namespace, true)
 
         DfE::Analytics::SendEvents.do([request_event.as_json])
+      end
+
+      private
+
+      def path_excluded?
+        excluded_path = DfE::Analytics.config.excluded_paths
+        excluded_path.any? do |path|
+          if path.is_a?(Regexp)
+            path.match?(request.fullpath)
+          else
+            request.fullpath.start_with?(path)
+          end
+        end
       end
     end
   end

--- a/spec/dfe/analytics/requests_spec.rb
+++ b/spec/dfe/analytics/requests_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe DfE::Analytics::Requests, type: :request do
       get '/regex_path/test' => 'test#index'
       get '/some/path/with/regex_path' => 'test#index'
       get '/another/path/to/regex_path' => 'test#index'
-      get '/included/path' => 'test#index' 
+      get '/included/path' => 'test#index'
     end
 
     ex.run
@@ -70,7 +70,7 @@ RSpec.describe DfE::Analytics::Requests, type: :request do
 
   before do
     DfE::Analytics.configure do |config|
-      config.excluded_paths = ['/healthcheck', %r{^/regex_path/.*$}, %r{regex_path$}]
+      config.excluded_paths = ['/healthcheck', %r{^/regex_path/.*$}, /regex_path$/]
     end
   end
 


### PR DESCRIPTION
Relates to [this ticket ](https://trello.com/c/URi1qr7E/1989-support-config-to-exclude-web-request-events-matching-a-string-or-regular-expression?filter=member:portererica)

Almost all services have had to find a work around to exclude the /healthcheck endpoint from being included as a web_request event. Currently there is no way of excluding this through the gem. 

This PR allows certain endpoints and paths to be excluded by allowing services to list these in their config file.