### PR TITLE
Update callbacks to have _commit suffix

### DIFF
--- a/lib/dfe/analytics/entities.rb
+++ b/lib/dfe/analytics/entities.rb
@@ -19,6 +19,9 @@ module DfE
         end
 
         after_update_commit do
+          # in this after_update hook we don't have access to the new fields via
+          # #attributes — we need to dig them out of saved_changes which stores
+          # them in the format { attr: ['old', 'new'] }
           updated_attributes = DfE::Analytics.extract_model_attributes(
             self, saved_changes.transform_values(&:last)
           )
@@ -39,7 +42,7 @@ module DfE
                                      .with_tags(event_tags)
                                      .with_request_uuid(RequestLocals.fetch(:dfe_analytics_request_id) { nil })
 
-        DfE::Analytics::SendEvents.perform_later([event.as_json])
+        DfE::Analytics::SendEvents.do([event.as_json])
       end
     end
   end

--- a/spec/dfe/analytics/entities_spec.rb
+++ b/spec/dfe/analytics/entities_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe DfE::Analytics::Entities do
           Candidate.create(id: 123, email_address: 'adrienne@example.com')
 
           expect(DfE::Analytics::SendEvents).to have_received(:perform_later)
-            .with([a_hash_including({
+            .with([a_hash_including({ # #match will cause a strict match within hash_including
               'data' => match([
                                 { 'key' => 'id', 'value' => [123] }
                               ])


### PR DESCRIPTION
ECF reported that they were seeing a disparity between production db numbers and BigQuery arising during a transaction - the event is sending straight away so if the transaction ends up rolling back the analytics event has already been sent to BQ and doesn’t match the db

This PR updates the callbacks (after_create after_update and after_destroy) to be after_create_commit `after_update_commit and after_destroy_commit so that events will only send after the transaction is complete but also if it rolls back the event will not send`

ECF did some testing of this update:

The issue was initially detected in the method save_and_dedupe_participant https://github.com/DFE-Digital/early-careers-framework/blob/main/app/models/npq_application.rb#L134. I've tested the fix locally by using some binding.pry statements to highlight where the analytics log events are occurring and if it's where we expect.
Pic 1: Before the change. Here we can see the event is logged before the transaction is complete. We've hit the pry while still in the transaction but the event has already been sent.
Pic 2: Now with the gem update. We hit the first pry we had before inside the transaction without logging an analytics event and we then publish the event before hitting the second pry outside the transaction. This is what we want. After the first, before the second.
Pic 3: Also with the gem update. I raised a rollback error inside the transaction and we completed the transaction without sending any event whatsoever which again is what we want.
![Screenshot 2024-07-29 at 16 52 30](https://github.com/user-attachments/assets/4326be2a-a7c2-4a39-af90-130246c2fe64)
![Screenshot 2024-07-29 at 16 45 14](https://github.com/user-attachments/assets/b4b12a18-ec4a-4b74-b51a-456b6c44cf41)
![Screenshot 2024-07-29 at 16 32 46](https://github.com/user-attachments/assets/f666f410-6e53-48eb-961b-1724a678f61e)
