### PR TITLE
Allow ordering by id if created_at/updated_at is null

### DIFF
--- a/lib/dfe/analytics/services/generic_checksum_calculator.rb
+++ b/lib/dfe/analytics/services/generic_checksum_calculator.rb
@@ -62,7 +62,8 @@ module DfE
         def build_where_clause(order_column, table_name_sanitized, checksum_calculated_at_sanitized)
           return '' unless WHERE_CLAUSE_ORDER_COLUMNS.map(&:downcase).include?(order_column.downcase)
 
-          "WHERE #{table_name_sanitized}.#{order_column.downcase} < #{checksum_calculated_at_sanitized}"
+          # Add IS NULL to include records with null updated_at / created_at values
+          "WHERE (#{table_name_sanitized}.#{order_column.downcase} IS NULL OR #{table_name_sanitized}.#{order_column.downcase} < #{checksum_calculated_at_sanitized})"
         end
       end
     end

--- a/spec/dfe/analytics/services/generic_checksum_calculator_spec.rb
+++ b/spec/dfe/analytics/services/generic_checksum_calculator_spec.rb
@@ -35,4 +35,20 @@ RSpec.describe DfE::Analytics::Services::GenericChecksumCalculator do
     expect(row_count).to eq(candidate_table_ids.count)
     expect(checksum).to eq(entity_table_checksum)
   end
+
+  it 'calculates checksum and correct row_count when updated_at has null values' do
+    Candidate.create(id: 1, email_address: 'candidate1@example.com', updated_at: nil)
+    Candidate.create(id: 2, email_address: 'candidate2@example.com', updated_at: nil)
+    Candidate.create(id: 3, email_address: 'candidate3@example.com', updated_at: Time.current - 1.day)
+    Candidate.create(id: 4, email_address: 'candidate4@example.com', updated_at: Time.current - 2.days)
+
+    order_column = 'ID' # defaults to ID when order_columns contain null values
+    expected_ids = [1, 2, 3, 4]
+    expected_checksum = Digest::MD5.hexdigest(expected_ids.join)
+
+    row_count, checksum = described_class.call(candidate_entity, order_column, checksum_calculated_at)
+
+    expect(row_count).to eq(4)
+    expect(checksum).to eq(expected_checksum)
+  end
 end


### PR DESCRIPTION
[Ticket](https://trello.com/c/F6HB3sf3/2099-investigate-rowcount-mismatches-on-findpub-and-teaching-vacancies)
Publish have a table "course_subjects" that has been long term out of sync with Big Query
Investigation showed this was because they have a number of records where updated_at is null and they were being excluded from the row_count during entity table check job / import entity rake task causing the row_count and checksum to not match
This is thought to apply to several other tables in Publish and to at least one other service

This PR updates:

 1) the entity_table_check_job to firstly order by created_at if updated_at has null values, and finally to default to ID if updated_at/created_at are missing or have null values
 2) the where clause to include order_by records with null values so that we get an accurate row count
