### PR TITLE
Config option to exclude models

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,3 +98,10 @@ en:
           description: |
             Google generated cloud credentials file
           default: ENV['GOOGLE_CLOUD_CREDENTIALS']
+        excluded_models_proc:
+          description: |
+            A proc which will be called during model initialization. It allows to disable models
+            which should not be used. Each model is passed to bloc and if bloc returns true for the model,
+            it wont be used by the application. Eg: proc { |x| x.to_s =~ /Namespace::/ } will exclude all
+            models namespaced with Namespace
+          default: proc { |_model| false }

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -58,6 +58,7 @@ module DfE
         gcp_scope
         google_cloud_credentials
         excluded_paths
+        excluded_models_proc
       ]
 
       @config ||= Struct.new(*configurables).new
@@ -84,6 +85,7 @@ module DfE
       config.bigquery_maintenance_window      ||= ENV.fetch('BIGQUERY_MAINTENANCE_WINDOW', nil)
       config.azure_federated_auth             ||= false
       config.excluded_paths                   ||= []
+      config.excluded_models_proc             ||= proc { |_model| false }
 
       return unless config.azure_federated_auth
 
@@ -257,6 +259,7 @@ module DfE
 
         ActiveRecord::Base.descendants
           .reject(&:abstract_class?)
+          .reject(&DfE::Analytics.config.excluded_models_proc)
           .group_by(&:table_name)
           .except(*rails_tables)
       end

--- a/spec/dfe/analytics_spec.rb
+++ b/spec/dfe/analytics_spec.rb
@@ -310,4 +310,33 @@ RSpec.describe DfE::Analytics do
       end
     end
   end
+
+  describe 'excluding models via configuration' do
+    with_model :Candidate do
+      table do |t|
+        t.string :email_address
+        t.string :first_name
+        t.string :last_name
+        t.string :dob
+      end
+    end
+
+    with_model :Teacher do
+      table do |t|
+        t.string :email_address
+        t.string :first_name
+        t.string :last_name
+        t.string :dob
+      end
+    end
+
+    before do
+      DfE::Analytics.config.excluded_models_proc = proc { |x| x.to_s =~ /Teacher/ }
+    end
+
+    it 'does not use disabled model' do
+      expect(DfE::Analytics.all_entities_in_application.length).to eq(1)
+      expect(DfE::Analytics.all_entities_in_application.first.to_s).to match(/with_model_candidates/)
+    end
+  end
 end


### PR DESCRIPTION
This pull request introduces a config option to disable one or more models entirely:

```
proc { |x| x.to_s =~ /Namespace::/ } will exclude all
```

In my application, there were 2 models with very similar names: `Namespace::Foo` and `Foo`, pointing to table `foos` in 2 different databases. Because `dfe-analytics` does not recognize namespaces or different databases, the above option is a viable solution to the problem. The reason for similar models/tables is migration - one application data is moving to another.
