### PR TITLE
v1.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v1.15.1](https://github.com/DFE-Digital/dfe-analytics/tree/v1.15.1) (2024-11-26)
+
+[Full Changelog](https://github.com/DFE-Digital/dfe-analytics/compare/v1.15.0...v1.15.1)
+
+**Merged pull requests:**
+
+- Fix WIF api call options [\#174](https://github.com/DFE-Digital/dfe-analytics/pull/174) ([asatwal](https://github.com/asatwal))
+
+- Upgrade to Ruby 3.3 [\#171](https://github.com/DFE-Digital/dfe-analytics/pull/171) ([goodviber](https://github.com/goodviber))
+
+- Config option to exclude models [\#169](https://github.com/DFE-Digital/dfe-analytics/pull/169) ([slawosz](https://github.com/slawosz))
+
 ## [v1.15.0](https://github.com/DFE-Digital/dfe-analytics/tree/v1.15.0) (2024-11-06)
 
 [Full Changelog](https://github.com/DFE-Digital/dfe-analytics/compare/v1.14.2...v1.15.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dfe-analytics (1.15.0)
+    dfe-analytics (1.15.1)
       google-cloud-bigquery (~> 1.38)
       httparty (~> 0.21)
       multi_xml (~> 0.6.0)

--- a/lib/dfe/analytics/version.rb
+++ b/lib/dfe/analytics/version.rb
@@ -2,6 +2,6 @@
 
 module DfE
   module Analytics
-    VERSION = '1.15.0'
+    VERSION = '1.15.1'
   end
 end


### PR DESCRIPTION
Release version 1.15.1 That contains the following:
- Fix WIF api call options
- Upgrade to Ruby 3.3
- Config option to exclude models