### PR TITLE
update error levels

### DIFF
--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -98,13 +98,13 @@ module DfE
     def self.initialize!
       unless defined?(ActiveRecord)
         # bail if we don't have AR at all
-        Rails.logger.info('ActiveRecord not loaded; DfE Analytics not initialized')
+        Rails.logger.error('ActiveRecord not loaded; DfE Analytics not initialized')
         return
       end
 
       unless Rails.env.production? || File.exist?(Rails.root.join('config/initializers/dfe_analytics.rb'))
         message = "Warning: DfE Analytics is not set up. Run: 'bundle exec rails generate dfe:analytics:install'"
-        Rails.logger.info(message)
+        Rails.logger.error(message)
         puts message
         return
       end
@@ -123,7 +123,7 @@ module DfE
         models_for_entity(entity).each do |m|
           m.include(DfE::Analytics::TransactionChanges)
           if m.include?(DfE::Analytics::Entities)
-            Rails.logger.info("DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (#{m.name}), but it's included automatically since v1.4. You're running v#{DfE::Analytics::VERSION}. To silence this warning, remove the include from model definitions in app/models.")
+            Rails.logger.warn("DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (#{m.name}), but it's included automatically since v1.4. You're running v#{DfE::Analytics::VERSION}. To silence this warning, remove the include from model definitions in app/models.")
           else
             m.include(DfE::Analytics::Entities)
             break
@@ -131,9 +131,9 @@ module DfE
         end
       end
     rescue ActiveRecord::PendingMigrationError
-      Rails.logger.info('Database requires migration; DfE Analytics not initialized')
+      Rails.logger.error('Database requires migration; DfE Analytics not initialized')
     rescue ActiveRecord::ActiveRecordError
-      Rails.logger.info('No database connection; DfE Analytics not initialized')
+      Rails.logger.error('No database connection; DfE Analytics not initialized')
     end
 
     def self.enabled?
@@ -276,13 +276,13 @@ module DfE
         end_time = Time.zone.parse(parsed_end_time.to_s)
 
         if start_time > end_time
-          Rails.logger.info('Start time is after end time in maintenance window configuration')
+          Rails.logger.warn('Start time is after end time in maintenance window configuration')
           return [nil, nil]
         end
 
         [start_time, end_time]
       rescue ArgumentError => e
-        Rails.logger.info("DfE::Analytics: Unexpected error in maintenance window configuration: #{e.message}")
+        Rails.logger.error("DfE::Analytics: Unexpected error in maintenance window configuration: #{e.message}")
         [nil, nil]
       end
     end

--- a/lib/dfe/analytics/send_events.rb
+++ b/lib/dfe/analytics/send_events.rb
@@ -5,7 +5,7 @@ module DfE
     class SendEvents < AnalyticsJob
       def self.do(events)
         unless DfE::Analytics.enabled?
-          Rails.logger.info('DfE::Analytics::SendEvents.do() called but DfE::Analytics is disabled. Please check DfE::Analytics.enabled? before sending events to BigQuery')
+          Rails.logger.warn('DfE::Analytics::SendEvents.do() called but DfE::Analytics is disabled. Please check DfE::Analytics.enabled? before sending events to BigQuery')
           return
         end
 

--- a/spec/dfe/analytics_spec.rb
+++ b/spec/dfe/analytics_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe DfE::Analytics do
     end
 
     it 'recovers and logs' do
-      expect(Rails.logger).to receive(:info).with(/No database connection/)
+      expect(Rails.logger).to receive(:error).with(/No database connection/)
       expect { DfE::Analytics.initialize! }.not_to raise_error
     end
   end
@@ -37,7 +37,7 @@ RSpec.describe DfE::Analytics do
     end
 
     it 'recovers and logs' do
-      expect(Rails.logger).to receive(:info).with(/No database connection/)
+      expect(Rails.logger).to receive(:error).with(/No database connection/)
       expect { DfE::Analytics.initialize! }.not_to raise_error
     end
   end
@@ -46,7 +46,7 @@ RSpec.describe DfE::Analytics do
     it 'recovers and logs' do
       allow(DfE::Analytics::Fields).to receive(:check!).and_raise(ActiveRecord::PendingMigrationError)
 
-      expect(Rails.logger).to receive(:info).with(/Database requires migration/)
+      expect(Rails.logger).to receive(:error).with(/Database requires migration/)
       expect { DfE::Analytics.initialize! }.not_to raise_error
     end
   end
@@ -55,7 +55,7 @@ RSpec.describe DfE::Analytics do
     it 'recovers and logs' do
       hide_const('ActiveRecord')
 
-      expect(Rails.logger).to receive(:info).with(/ActiveRecord not loaded/)
+      expect(Rails.logger).to receive(:error).with(/ActiveRecord not loaded/)
       expect { DfE::Analytics.initialize! }.not_to raise_error
     end
   end
@@ -137,11 +137,11 @@ RSpec.describe DfE::Analytics do
       end
 
       it 'logs deprecation warnings' do
-        allow(Rails.logger).to receive(:info).and_call_original
+        allow(Rails.logger).to receive(:warn).and_call_original
 
         DfE::Analytics.initialize!
 
-        expect(Rails.logger).to have_received(:info).twice.with(/DEPRECATION WARNING/)
+        expect(Rails.logger).to have_received(:warn).twice.with(/DEPRECATION WARNING/)
       end
     end
   end
@@ -260,7 +260,7 @@ RSpec.describe DfE::Analytics do
       end
 
       it 'logs an error and returns [nil, nil]' do
-        expect(Rails.logger).to receive(:info).with(/Start time is after end time/)
+        expect(Rails.logger).to receive(:warn).with(/Start time is after end time/)
         expect(described_class.parse_maintenance_window).to eq([nil, nil])
       end
     end
@@ -272,7 +272,7 @@ RSpec.describe DfE::Analytics do
       end
 
       it 'logs an error and returns [nil, nil]' do
-        expect(Rails.logger).to receive(:info).with(/Unexpected error/)
+        expect(Rails.logger).to receive(:error).with(/Unexpected error/)
         expect(described_class.parse_maintenance_window).to eq([nil, nil])
       end
     end


### PR DESCRIPTION
We are rescuing initialisation and other errors with Rails.logger.info messages, which makes them difficult to find In the output logs. This PR updates the relevant info messages to error or warn level