### PR TITLE
Add support for api_request events

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ gem 'dfe-analytics'
 gem 'globalize' require: ['dfe-analytics', 'globalize']
 ```
 
-### 6. Send web request events
+### 6. Send request events
 
 #### Web requests
 
@@ -259,7 +259,29 @@ class ApplicationController < ActionController::Base
 end
 ```
 
-Web request events will try to add a `user_id` to the event data sent to
+#### API requests
+
+Including `DfE::Analytics::ApiRequests` in your `ApiController` will cause
+it and all inheriting controllers to send api request events to BigQuery. (This
+is probably what you want).
+
+```ruby
+class ApiController < ActionController::API
+  include DfE::Analytics::ApiRequests
+
+  # This method MAY be present in your controller, returning
+  # either nil or an object implementing an .id method.
+  #
+  # def current_user; end
+
+  # This method MAY be present in your controller. If so, it should
+  # return a string - return value will be attached to api_request events.
+  #
+  # def current_namespace; end
+end
+```
+
+Request events will try to add a `user_id` to the event data sent to
 BigQuery. The `user_id` will only be populated if the controller defines a
 `current_user` method whose return value responds to `.id`.
 
@@ -270,7 +292,7 @@ user identifier proc can be defined in `config/initializers/dfe_analytics.rb`:
 DfE::Analytics.config.user_identifier = proc { |user| user&.uid }
 ```
 
-You can specify paths that should be excluded from logging using the skip_web_requests configuration option. This is useful for endpoints like health checks that are frequently hit and do not need to be logged.
+You can specify paths that should be excluded from sending request events using the excluded_paths configuration option. This is useful for endpoints like health checks that are frequently hit and do not need to generate an event.
 
 ```ruby
 DfE::Analytics.configure do |config|

--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -12,6 +12,7 @@ require 'dfe/analytics/services/checksum_calculator'
 require 'dfe/analytics/services/generic_checksum_calculator'
 require 'dfe/analytics/services/postgres_checksum_calculator'
 require 'dfe/analytics/shared/service_pattern'
+require 'dfe/analytics/concerns/requestable'
 require 'dfe/analytics/event'
 require 'dfe/analytics/event_matcher'
 require 'dfe/analytics/analytics_job'
@@ -29,6 +30,7 @@ require 'dfe/analytics/big_query_api'
 require 'dfe/analytics/big_query_legacy_api'
 require 'dfe/analytics/azure_federated_auth'
 require 'dfe/analytics/transaction_changes'
+require 'dfe/analytics/api_requests'
 
 module DfE
   module Analytics

--- a/lib/dfe/analytics/api_requests.rb
+++ b/lib/dfe/analytics/api_requests.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module DfE
+  module Analytics
+    # This module provides functionality to generate api_request events through an after action controller callback
+    module ApiRequests
+      extend ActiveSupport::Concern
+
+      included do
+        after_action :trigger_api_request_event
+      end
+
+      include Dfe::Analytics::Concerns::Requestable
+
+      def trigger_api_request_event
+        trigger_request_event('api_request')
+      end
+    end
+  end
+end

--- a/lib/dfe/analytics/concerns/requestable.rb
+++ b/lib/dfe/analytics/concerns/requestable.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Dfe
+  module Analytics
+    module Concerns
+      # This module provides common functionality to generate request events for the given event type
+      module Requestable
+        def trigger_request_event(event_type)
+          return unless DfE::Analytics.enabled?
+          return if path_excluded?
+
+          request_event = DfE::Analytics::Event.new
+                                               .with_type(event_type)
+                                               .with_request_details(request)
+                                               .with_response_details(response)
+                                               .with_request_uuid(RequestLocals.fetch(:dfe_analytics_request_id) { nil })
+
+          request_event.with_user(current_user)           if respond_to?(:current_user, true)
+          request_event.with_namespace(current_namespace) if respond_to?(:current_namespace, true)
+
+          DfE::Analytics::SendEvents.do([request_event.as_json])
+        end
+
+        private
+
+        def path_excluded?
+          excluded_path = DfE::Analytics.config.excluded_paths
+          excluded_path.any? do |path|
+            if path.is_a?(Regexp)
+              path.match?(request.fullpath)
+            else
+              request.fullpath.start_with?(path)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dfe/analytics/event.rb
+++ b/lib/dfe/analytics/event.rb
@@ -6,7 +6,7 @@ module DfE
   module Analytics
     class Event
       EVENT_TYPES = %w[
-        web_request create_entity update_entity delete_entity import_entity initialise_analytics entity_table_check import_entity_table_check
+        web_request create_entity update_entity delete_entity import_entity initialise_analytics entity_table_check import_entity_table_check api_request
       ].freeze
 
       def initialize

--- a/lib/dfe/analytics/requests.rb
+++ b/lib/dfe/analytics/requests.rb
@@ -2,40 +2,18 @@
 
 module DfE
   module Analytics
+    # This module provides functionality to generate web_request events through an after action controller callback
     module Requests
       extend ActiveSupport::Concern
 
       included do
-        after_action :trigger_request_event
+        after_action :trigger_web_request_event
       end
 
-      def trigger_request_event
-        return unless DfE::Analytics.enabled?
-        return if path_excluded?
+      include Dfe::Analytics::Concerns::Requestable
 
-        request_event = DfE::Analytics::Event.new
-                                             .with_type('web_request')
-                                             .with_request_details(request)
-                                             .with_response_details(response)
-                                             .with_request_uuid(RequestLocals.fetch(:dfe_analytics_request_id) { nil })
-
-        request_event.with_user(current_user)           if respond_to?(:current_user, true)
-        request_event.with_namespace(current_namespace) if respond_to?(:current_namespace, true)
-
-        DfE::Analytics::SendEvents.do([request_event.as_json])
-      end
-
-      private
-
-      def path_excluded?
-        excluded_path = DfE::Analytics.config.excluded_paths
-        excluded_path.any? do |path|
-          if path.is_a?(Regexp)
-            path.match?(request.fullpath)
-          else
-            request.fullpath.start_with?(path)
-          end
-        end
+      def trigger_web_request_event
+        trigger_request_event('web_request')
       end
     end
   end

--- a/spec/dfe/analytics/api_requests_spec.rb
+++ b/spec/dfe/analytics/api_requests_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+RSpec.describe DfE::Analytics::ApiRequests, type: :request do
+  before do
+    controller = Class.new(ApplicationController) do
+      include DfE::Analytics::ApiRequests
+
+      def index
+        render plain: 'hello'
+      end
+
+      private
+
+      def current_user
+        Struct.new(:id).new(1)
+      end
+
+      def current_namespace
+        'example_namespace'
+      end
+    end
+
+    unauthenticated_controller = Class.new(ApplicationController) do
+      include DfE::Analytics::ApiRequests
+
+      def index
+        render plain: 'hello'
+      end
+    end
+
+    stub_const('TestController', controller)
+    stub_const('TestUnauthenticatedController', unauthenticated_controller)
+  end
+
+  around do |ex|
+    Rails.application.routes.draw do
+      get '/example/path' => 'test#index'
+      get '/unauthenticated_example' => 'test_unauthenticated#index'
+      get '/healthcheck' => 'test#index'
+      get '/regex_path/test' => 'test#index'
+      get '/some/path/with/regex_path' => 'test#index'
+      get '/another/path/to/regex_path' => 'test#index'
+      get '/included/path' => 'test#index'
+    end
+
+    ex.run
+  ensure
+    Rails.application.routes_reloader.reload!
+  end
+
+  let!(:event) do
+    { environment: 'test',
+      event_type: 'api_request',
+      request_user_agent: 'Test agent',
+      request_method: 'GET',
+      request_path: '/example/path',
+      request_query: [{ key: 'page',
+                        value: ['1'] },
+                      { key: 'per_page',
+                        value: ['25'] },
+                      { key: 'array_param[]',
+                        value: %w[1 2] }],
+      request_referer: nil,
+      anonymised_user_agent_and_ip: '6b3f52c670279e133a78a03e34eea436c65395417ec264eb9f8c1e6da4f5ed56',
+      response_content_type: 'text/plain; charset=utf-8',
+      response_status: 200,
+      namespace: 'example_namespace',
+      user_id: 1 }
+  end
+
+  before do
+    DfE::Analytics.configure do |config|
+      config.excluded_paths = ['/healthcheck', %r{^/regex_path/.*$}, /regex_path$/]
+    end
+  end
+
+  it 'sends request data to BigQuery' do
+    request = stub_analytics_event_submission
+    DfE::Analytics::Testing.webmock! do
+      perform_enqueued_jobs do
+        get('/example/path',
+            params: { page: '1', per_page: '25', array_param: %w[1 2] },
+            headers: { 'HTTP_USER_AGENT' => 'Test agent', 'X-REAL-IP' => '1.2.3.4' })
+      end
+    end
+
+    expect(request.with do |req|
+      body = JSON.parse(req.body)
+      payload = body['rows'].first['json']
+      expect(payload.except('occurred_at', 'request_uuid')).to match(event.deep_stringify_keys)
+    end).to have_been_made
+  end
+
+  describe 'an event without user or namespace' do
+    let!(:event) do
+      { environment: 'test',
+        event_type: 'api_request',
+        request_user_agent: nil,
+        request_method: 'GET',
+        request_path: '/unauthenticated_example',
+        request_query: [],
+        request_referer: nil,
+        anonymised_user_agent_and_ip: '6694f83c9f476da31f5df6bcc520034e7e57d421d247b9d34f49edbfc84a764c',
+        response_content_type: 'text/plain; charset=utf-8',
+        response_status: 200 }
+    end
+
+    it 'does not require a user' do
+      request = stub_analytics_event_submission
+
+      DfE::Analytics::Testing.webmock! do
+        perform_enqueued_jobs do
+          get('/unauthenticated_example',
+              headers: { 'X-REAL-IP' => '1.2.3.4' })
+        end
+      end
+
+      expect(request.with do |req|
+        body = JSON.parse(req.body)
+        payload = body['rows'].first['json']
+        expect(payload.except('occurred_at', 'request_uuid')).to match(event.deep_stringify_keys)
+      end).to have_been_made
+    end
+  end
+
+  context 'when request path is in the skip list' do
+    it 'does not send healthcheck request data to BigQuery' do
+      request = stub_analytics_event_submission
+
+      DfE::Analytics::Testing.webmock! do
+        perform_enqueued_jobs do
+          get('/healthcheck')
+        end
+      end
+
+      expect(request).not_to have_been_made
+    end
+
+    it 'does not send regex_path/test request data to BigQuery' do
+      request = stub_analytics_event_submission
+
+      DfE::Analytics::Testing.webmock! do
+        perform_enqueued_jobs do
+          get('/regex_path/test')
+        end
+      end
+
+      expect(request).not_to have_been_made
+    end
+
+    it 'does not send some/path/with/regex_path request data to BigQuery' do
+      request = stub_analytics_event_submission
+
+      DfE::Analytics::Testing.webmock! do
+        perform_enqueued_jobs do
+          get('/some/path/with/regex_path')
+        end
+      end
+
+      expect(request).not_to have_been_made
+    end
+
+    it 'does not send another/path/to/regex_path request data to BigQuery' do
+      request = stub_analytics_event_submission
+
+      DfE::Analytics::Testing.webmock! do
+        perform_enqueued_jobs do
+          get('/another/path/to/regex_path')
+        end
+      end
+
+      expect(request).not_to have_been_made
+    end
+  end
+end

--- a/spec/dfe/analytics/rspec/matchers/have_been_enqueued_as_analytics_events_spec.rb
+++ b/spec/dfe/analytics/rspec/matchers/have_been_enqueued_as_analytics_events_spec.rb
@@ -14,12 +14,19 @@ RSpec.describe 'have_been_enqueued_as_analytics_events matcher' do
   end
 
   let(:web_request_event) { DfE::Analytics::Event.new.with_type('web_request') }
+  let(:api_request_event) { DfE::Analytics::Event.new.with_type('api_request') }
   let(:update_entity_event) { DfE::Analytics::Event.new.with_type('update_entity') }
 
-  it 'passes when the given event type was triggered' do
+  it 'passes when the web request event type was triggered' do
     DfE::Analytics::SendEvents.do([web_request_event.as_json])
 
     expect(:web_request).to have_been_enqueued_as_analytics_events
+  end
+
+  it 'passes when the api request event type was triggered' do
+    DfE::Analytics::SendEvents.do([api_request_event.as_json])
+
+    expect(:api_request).to have_been_enqueued_as_analytics_events
   end
 
   it 'accepts multiple event types' do
@@ -49,9 +56,11 @@ RSpec.describe 'have_been_enqueued_as_analytics_events matcher' do
   it 'passes if other analytics events were triggered in addition to the specified analytics type' do
     DfE::Analytics::SendEvents.do([update_entity_event.as_json])
     DfE::Analytics::SendEvents.do([web_request_event.as_json])
+    DfE::Analytics::SendEvents.do([api_request_event.as_json])
 
     expect(:update_entity).to have_been_enqueued_as_analytics_events
     expect(:web_request).to have_been_enqueued_as_analytics_events
+    expect(:api_request).to have_been_enqueued_as_analytics_events
   end
 
   it 'passes if other jobs were triggered in addition to the specified analytics type' do

--- a/spec/dfe/analytics/rspec/matchers/have_sent_analytics_event_types_spec.rb
+++ b/spec/dfe/analytics/rspec/matchers/have_sent_analytics_event_types_spec.rb
@@ -14,12 +14,19 @@ RSpec.describe 'have_sent_analytics_event_types matcher' do
   end
 
   let(:web_request_event) { DfE::Analytics::Event.new.with_type('web_request') }
+  let(:api_request_event) { DfE::Analytics::Event.new.with_type('api_request') }
   let(:update_entity_event) { DfE::Analytics::Event.new.with_type('update_entity') }
 
-  it 'passes when the given event type was triggered' do
+  it 'passes when the web request event type was triggered' do
     expect do
       DfE::Analytics::SendEvents.do([web_request_event.as_json])
     end.to have_sent_analytics_event_types(:web_request)
+  end
+
+  it 'passes when the api request event type was triggered' do
+    expect do
+      DfE::Analytics::SendEvents.do([api_request_event.as_json])
+    end.to have_sent_analytics_event_types(:api_request)
   end
 
   it 'accepts multiple event types' do
@@ -32,7 +39,7 @@ RSpec.describe 'have_sent_analytics_event_types matcher' do
   it 'fails if only one event type has been sent' do
     expect do
       DfE::Analytics::SendEvents.do([update_entity_event.as_json])
-    end.not_to have_sent_analytics_event_types(:web_request, :update_entity)
+    end.not_to have_sent_analytics_event_types(:api_request, :web_request, :update_entity)
   end
 
   it 'fails when no event is triggered' do


### PR DESCRIPTION
### Context
Add support for api_request events.

### Trello tickets:
https://trello.com/c/bbU5kOXr

### Changes proposed in this pull request
Add api_request event types as standard.

Update documentation on how to use API Request events.