### PR TITLE
Ensure API Request events always sent

### DIFF
--- a/lib/dfe/analytics/api_requests.rb
+++ b/lib/dfe/analytics/api_requests.rb
@@ -7,12 +7,14 @@ module DfE
       extend ActiveSupport::Concern
 
       included do
-        after_action :trigger_api_request_event
+        around_action :trigger_api_request_event
       end
 
       include Dfe::Analytics::Concerns::Requestable
 
       def trigger_api_request_event
+        yield # Let the request lifecycle proceed
+      ensure
         trigger_request_event('api_request')
       end
     end


### PR DESCRIPTION
### Context
Ensure API Request events always sent, event if there is an error code returned.

Trello tickets:
https://trello.com/c/bbU5kOXr

Changes proposed in this pull request
Add around_action callback for api_request event types with ensure block.
