### PR TITLE
rm updated_at in checksum calculators

### DIFF
--- a/lib/dfe/analytics/services/entity_table_checks.rb
+++ b/lib/dfe/analytics/services/entity_table_checks.rb
@@ -59,7 +59,7 @@ module DfE
 
         def order_column_exposed_for_entity?(entity_name, columns)
           return false if columns.nil?
-          return true if columns.any? { |column| %w[updated_at created_at id].include?(column) }
+          return true if columns.any? { |column| %w[created_at id].include?(column) }
 
           Rails.logger.info("DfE::Analytics Processing entity: Order columns missing in analytics.yml for #{entity_name} - Skipping checks")
 
@@ -67,9 +67,7 @@ module DfE
         end
 
         def determine_order_column(entity_name, columns)
-          if connection.column_exists?(entity_name, :updated_at) && columns.include?('updated_at') && !null_values_in_column?('updated_at')
-            'UPDATED_AT'
-          elsif connection.column_exists?(entity_name, :created_at) && columns.include?('created_at') && !null_values_in_column?('created_at')
+          if connection.column_exists?(entity_name, :created_at) && columns.include?('created_at') && !null_values_in_column?('created_at')
             'CREATED_AT'
           elsif connection.column_exists?(entity_name, :id) && columns.include?('id')
             'ID'

--- a/lib/dfe/analytics/services/generic_checksum_calculator.rb
+++ b/lib/dfe/analytics/services/generic_checksum_calculator.rb
@@ -60,7 +60,7 @@ module DfE
         def build_where_clause(order_column, table_name_sanitized, checksum_calculated_at_sanitized)
           return '' unless order_column.downcase == 'created_at'
 
-          "WHERE (#{table_name_sanitized}.#{order_column.downcase} IS NULL OR DATE_TRUNC('milliseconds', #{table_name_sanitized}.#{order_column.downcase}) < DATE_TRUNC('milliseconds', #{checksum_calculated_at_sanitized}::timestamp))"
+          "WHERE (#{table_name_sanitized}.#{order_column.downcase} IS NULL OR #{table_name_sanitized}.#{order_column.downcase} < #{checksum_calculated_at_sanitized})"
         end
       end
     end

--- a/lib/dfe/analytics/services/postgres_checksum_calculator.rb
+++ b/lib/dfe/analytics/services/postgres_checksum_calculator.rb
@@ -8,8 +8,6 @@ module DfE
       class PostgresChecksumCalculator
         include ServicePattern
 
-        WHERE_CLAUSE_ORDER_COLUMNS = %w[CREATED_AT UPDATED_AT].freeze
-
         def initialize(entity, order_column, checksum_calculated_at)
           @entity = entity
           @order_column = order_column
@@ -50,13 +48,13 @@ module DfE
 
         def build_select_and_order_clause(order_column, table_name_sanitized)
           order_alias = case order_column
-                        when 'UPDATED_AT', 'CREATED_AT'
+                        when 'CREATED_AT'
                           "#{order_column.downcase}_alias"
                         else
                           'id_alias'
                         end
           select_clause = case order_column
-                          when 'UPDATED_AT', 'CREATED_AT'
+                          when 'CREATED_AT'
                             "DATE_TRUNC('milliseconds', #{table_name_sanitized}.#{order_column.downcase}) AS \"#{order_alias}\""
                           else
                             "#{table_name_sanitized}.id::TEXT AS \"#{order_alias}\""
@@ -65,9 +63,9 @@ module DfE
         end
 
         def build_where_clause(order_column, table_name_sanitized, checksum_calculated_at_sanitized)
-          return '' unless WHERE_CLAUSE_ORDER_COLUMNS.map(&:downcase).include?(order_column.downcase)
+          return '' unless order_column.downcase == 'created_at'
 
-          # Add IS NULL to include records with null updated_at / created_at values
+          # Add IS NULL to include records with null created_at values
           "WHERE (#{table_name_sanitized}.#{order_column.downcase} IS NULL OR DATE_TRUNC('milliseconds', #{table_name_sanitized}.#{order_column.downcase}) < DATE_TRUNC('milliseconds', #{checksum_calculated_at_sanitized}::timestamp))"
         end
       end

--- a/spec/dfe/analytics/send_events_spec.rb
+++ b/spec/dfe/analytics/send_events_spec.rb
@@ -46,10 +46,10 @@ RSpec.describe DfE::Analytics::SendEvents do
 
       it 'logs events with all sensitive data masked' do
         expect(Rails.logger).to receive(:info) do |log_message|
-          expect(log_message).to include('"key" => "dob", "value" => ["HIDDEN"]')
-          expect(log_message).to include('"key" => "first_name", "value" => ["HIDDEN"]')
-          expect(log_message).to include('"key" => "email", "value" => "user@example.com"')
-          expect(log_message).to include('"key" => "phone_number", "value" => "1234567890"')
+          expect(log_message).to include('"key"=>"dob", "value"=>["HIDDEN"]')
+          expect(log_message).to include('"key"=>"first_name", "value"=>["HIDDEN"]')
+          expect(log_message).to include('"key"=>"email", "value"=>"user@example.com"')
+          expect(log_message).to include('"key"=>"phone_number", "value"=>"1234567890"')
         end
 
         described_class.new.perform([hidden_pii_event])
@@ -121,10 +121,10 @@ RSpec.describe DfE::Analytics::SendEvents do
 
       it 'masks sensitive data in the log output' do
         expect(Rails.logger).to receive(:info) do |log_message|
-          expect(log_message).to include('"key" => "dob", "value" => ["HIDDEN"]')
-          expect(log_message).to include('"key" => "first_name", "value" => ["HIDDEN"]')
-          expect(log_message).to include('"key" => "email", "value" => "user@example.com"')
-          expect(log_message).to include('"key" => "phone_number", "value" => "1234567890"')
+          expect(log_message).to include('"key"=>"dob", "value"=>["HIDDEN"]')
+          expect(log_message).to include('"key"=>"first_name", "value"=>["HIDDEN"]')
+          expect(log_message).to include('"key"=>"email", "value"=>"user@example.com"')
+          expect(log_message).to include('"key"=>"phone_number", "value"=>"1234567890"')
         end
 
         described_class.new.perform([hidden_pii_event])

--- a/spec/dfe/analytics/send_events_spec.rb
+++ b/spec/dfe/analytics/send_events_spec.rb
@@ -46,10 +46,10 @@ RSpec.describe DfE::Analytics::SendEvents do
 
       it 'logs events with all sensitive data masked' do
         expect(Rails.logger).to receive(:info) do |log_message|
-          expect(log_message).to include('"key"=>"dob", "value"=>["HIDDEN"]')
-          expect(log_message).to include('"key"=>"first_name", "value"=>["HIDDEN"]')
-          expect(log_message).to include('"key"=>"email", "value"=>"user@example.com"')
-          expect(log_message).to include('"key"=>"phone_number", "value"=>"1234567890"')
+          expect(log_message).to include('"key" => "dob", "value" => ["HIDDEN"]')
+          expect(log_message).to include('"key" => "first_name", "value" => ["HIDDEN"]')
+          expect(log_message).to include('"key" => "email", "value" => "user@example.com"')
+          expect(log_message).to include('"key" => "phone_number", "value" => "1234567890"')
         end
 
         described_class.new.perform([hidden_pii_event])
@@ -121,10 +121,10 @@ RSpec.describe DfE::Analytics::SendEvents do
 
       it 'masks sensitive data in the log output' do
         expect(Rails.logger).to receive(:info) do |log_message|
-          expect(log_message).to include('"key"=>"dob", "value"=>["HIDDEN"]')
-          expect(log_message).to include('"key"=>"first_name", "value"=>["HIDDEN"]')
-          expect(log_message).to include('"key"=>"email", "value"=>"user@example.com"')
-          expect(log_message).to include('"key"=>"phone_number", "value"=>"1234567890"')
+          expect(log_message).to include('"key" => "dob", "value" => ["HIDDEN"]')
+          expect(log_message).to include('"key" => "first_name", "value" => ["HIDDEN"]')
+          expect(log_message).to include('"key" => "email", "value" => "user@example.com"')
+          expect(log_message).to include('"key" => "phone_number", "value" => "1234567890"')
         end
 
         described_class.new.perform([hidden_pii_event])

--- a/spec/dfe/analytics/services/entity_table_checks_spec.rb
+++ b/spec/dfe/analytics/services/entity_table_checks_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe DfE::Analytics::Services::EntityTableChecks do
 
   describe '#call' do
     let(:time_zone) { 'London' }
-    let(:order_column) { 'UPDATED_AT' }
+    let(:order_column) { 'CREATED_AT' }
     let(:course_entity) { DfE::Analytics.entities_for_analytics.find { |entity| entity.to_s.include?('course') } }
     let(:institution_entity) { DfE::Analytics.entities_for_analytics.find { |entity| entity.to_s.include?('institution') } }
     let(:application_entity) { DfE::Analytics.entities_for_analytics.find { |entity| entity.to_s.include?('application') } }
@@ -97,11 +97,11 @@ RSpec.describe DfE::Analytics::Services::EntityTableChecks do
       expect(Rails.logger).to have_received(:info).with(expected_message)
     end
 
-    it 'uses updated_at if it exists and has no null values' do
-      Candidate.create!(id: 1, email_address: 'first@example.com', updated_at: Time.current)
-      Candidate.create!(id: 2, email_address: 'second@example.com', updated_at: Time.current + 1.minute)
+    it 'uses created_at if it exists and has no null values' do
+      Candidate.create!(id: 1, email_address: 'first@example.com')
+      Candidate.create!(id: 2, email_address: 'second@example.com')
 
-      table_ids = Candidate.order(:updated_at).pluck(:id)
+      table_ids = Candidate.order(:created_at).pluck(:id)
       checksum = Digest::MD5.hexdigest(table_ids.join)
 
       described_class.call(entity_name: candidate_entity, entity_type: entity_type, entity_tag: nil)
@@ -112,12 +112,12 @@ RSpec.describe DfE::Analytics::Services::EntityTableChecks do
             { 'key' => 'row_count', 'value' => [table_ids.size] },
             { 'key' => 'checksum', 'value' => [checksum] },
             { 'key' => 'checksum_calculated_at', 'value' => [checksum_calculated_at] },
-            { 'key' => 'order_column', 'value' => ['UPDATED_AT'] }
+            { 'key' => 'order_column', 'value' => [order_column] }
           ]
       })])
     end
 
-    it 'falls back to id when both updated_at and created_at are null' do
+    it 'falls back to id when created_at is null' do
       frozen_time = Time.zone.now.in_time_zone('London')
       Timecop.freeze(frozen_time)
 
@@ -125,9 +125,9 @@ RSpec.describe DfE::Analytics::Services::EntityTableChecks do
       candidate2 = Candidate.create!(id: 2, email_address: 'second@example.com')
       candidate3 = Candidate.create!(id: 3, email_address: 'third@example.com')
 
-      candidate1.update_columns(created_at: nil, updated_at: nil)
-      candidate2.update_columns(created_at: nil, updated_at: nil)
-      candidate3.update_columns(created_at: nil, updated_at: nil)
+      candidate1.update_columns(created_at: nil)
+      candidate2.update_columns(created_at: nil)
+      candidate3.update_columns(created_at: nil)
 
       table_ids = Candidate.order(:id).pluck(:id)
       checksum = Digest::MD5.hexdigest(table_ids.join)
@@ -147,13 +147,13 @@ RSpec.describe DfE::Analytics::Services::EntityTableChecks do
       Timecop.return
     end
 
-    it 'falls back to created_at when updated_at is null but created_at exists' do
+    it 'defaults to created_at when updated_at is null but created_at exists' do
       Candidate.create!(id: 1, email_address: 'first@example.com', updated_at: nil, created_at: 2.hours.ago)
       Candidate.create!(id: 2, email_address: 'second@example.com', updated_at: nil, created_at: 1.hour.ago)
       Candidate.create!(id: 3, email_address: 'third@example.com', updated_at: nil, created_at: 3.hours.ago)
 
-      # Ensure updated_at is nil
-      Candidate.update_all(updated_at: nil)
+      # Ensure updated_at is not nil
+      Candidate.update_all(updated_at: Time.now)
 
       table_ids = Candidate.order(:created_at).pluck(:id)
       checksum = Digest::MD5.hexdigest(table_ids.join)
@@ -195,7 +195,7 @@ RSpec.describe DfE::Analytics::Services::EntityTableChecks do
     it 'sends an entity table check event' do
       [130, 131, 132].map { |id| Candidate.create(id: id) }
       candidate_entities = DfE::Analytics.entities_for_analytics.select { |entity| entity.to_s.include?('candidate') }
-      table_ids = Candidate.where('updated_at < ?', checksum_calculated_at).order(updated_at: :asc).pluck(:id)
+      table_ids = Candidate.where('created_at < ?', checksum_calculated_at).order(created_at: :asc).pluck(:id)
       checksum = Digest::MD5.hexdigest(table_ids.join)
 
       candidate_entities.each do |candidate|
@@ -214,7 +214,7 @@ RSpec.describe DfE::Analytics::Services::EntityTableChecks do
     end
 
     it 'returns zero rows and checksum if table is empty' do
-      table_ids = Candidate.where('updated_at < ?', checksum_calculated_at).order(updated_at: :asc).pluck(:id)
+      table_ids = Candidate.where('created_at < ?', checksum_calculated_at).order(created_at: :asc).pluck(:id)
       checksum = Digest::MD5.hexdigest(table_ids.join)
       described_class.call(entity_name: candidate_entity, entity_type: entity_type, entity_tag: nil)
 
@@ -249,7 +249,7 @@ RSpec.describe DfE::Analytics::Services::EntityTableChecks do
       end
     end
 
-    it 'orders by id if created_at and updated_at are missing for Institution' do
+    it 'orders by id if created_at is missing for Institution' do
       order_column = 'ID'
 
       ['Institute A', 'Institute B', 'Institute C'].each { |name| Institution.create(name: name, address: 'Some address') }
@@ -273,14 +273,14 @@ RSpec.describe DfE::Analytics::Services::EntityTableChecks do
       end
     end
 
-    it 'orders records by updated_at truncated to milliseconds' do
+    it 'orders records by created_at truncated to milliseconds' do
       time_base = Time.zone.now.beginning_of_minute
-      Candidate.create(email_address: 'first@example.com', updated_at: time_base + 0.001.seconds)
-      Candidate.create(email_address: 'second@example.com', updated_at: time_base + 0.005.seconds)
+      Candidate.create(email_address: 'first@example.com')
+      Candidate.create(email_address: 'second@example.com')
 
       described_class.call(entity_name: candidate_entity, entity_type: entity_type, entity_tag: nil)
 
-      ordered_candidates = Candidate.order(:updated_at).pluck(:email_address)
+      ordered_candidates = Candidate.order(:created_at).pluck(:email_address)
 
       expect(ordered_candidates).to eq(['first@example.com', 'second@example.com'])
     end

--- a/spec/dfe/analytics/services/entity_table_checks_spec.rb
+++ b/spec/dfe/analytics/services/entity_table_checks_spec.rb
@@ -213,27 +213,6 @@ RSpec.describe DfE::Analytics::Services::EntityTableChecks do
       end
     end
 
-    it 'does not send the event if updated_at is greater than checksum_calculated_at' do
-      Candidate.create(id: '123', updated_at: DateTime.parse(checksum_calculated_at) - 2.hours)
-      Candidate.create(id: '124', updated_at: DateTime.parse(checksum_calculated_at) - 5.hours)
-      Candidate.create(id: '125', updated_at: DateTime.parse(checksum_calculated_at) + 5.hours)
-
-      table_ids = Candidate.where('updated_at < ?', checksum_calculated_at).order(:updated_at).pluck(:id)
-      checksum = Digest::MD5.hexdigest(table_ids.join)
-
-      described_class.call(entity_name: candidate_entity, entity_type: entity_type, entity_tag: nil)
-
-      expect(DfE::Analytics::SendEvents).to have_received(:perform_later)
-        .with([a_hash_including({
-          'data' => [
-            { 'key' => 'row_count', 'value' => [table_ids.size] },
-            { 'key' => 'checksum', 'value' => [checksum] },
-            { 'key' => 'checksum_calculated_at', 'value' => [checksum_calculated_at] },
-            { 'key' => 'order_column', 'value' => [order_column] }
-          ]
-      })])
-    end
-
     it 'returns zero rows and checksum if table is empty' do
       table_ids = Candidate.where('updated_at < ?', checksum_calculated_at).order(updated_at: :asc).pluck(:id)
       checksum = Digest::MD5.hexdigest(table_ids.join)

--- a/spec/dfe/analytics/services/entity_table_checks_spec.rb
+++ b/spec/dfe/analytics/services/entity_table_checks_spec.rb
@@ -274,7 +274,6 @@ RSpec.describe DfE::Analytics::Services::EntityTableChecks do
     end
 
     it 'orders records by created_at truncated to milliseconds' do
-      time_base = Time.zone.now.beginning_of_minute
       Candidate.create(email_address: 'first@example.com')
       Candidate.create(email_address: 'second@example.com')
 


### PR DESCRIPTION
We are getting chacksum mismatched where we have identical row counts but differing updated at values for various reasons. We have decided to remove the updated_at values from the checksum calculators.

I think this will also need to be matched in dataform 