### PR TITLE
Fix "async" config setup

### DIFF
--- a/lib/dfe/analytics.rb
+++ b/lib/dfe/analytics.rb
@@ -74,7 +74,6 @@ module DfE
       config.bigquery_timeout                 ||= 120
       config.environment                      ||= ENV.fetch('RAILS_ENV', 'development')
       config.log_only                         ||= false
-      config.async                            ||= true
       config.queue                            ||= :default
       config.user_identifier                  ||= proc { |user| user&.id }
       config.entity_table_checks_enabled      ||= false
@@ -83,6 +82,7 @@ module DfE
       config.azure_federated_auth             ||= false
       config.excluded_paths                   ||= []
       config.excluded_models_proc             ||= proc { |_model| false }
+      config.async = true if config.async.nil?
 
       return unless config.azure_federated_auth
 

--- a/spec/dfe/analytics_spec.rb
+++ b/spec/dfe/analytics_spec.rb
@@ -189,6 +189,38 @@ RSpec.describe DfE::Analytics do
     end
   end
 
+  describe '.async?' do
+    context 'when the async config has been set to true' do
+      before do
+        described_class.configure { |config| config.async = true }
+      end
+
+      it 'returns true' do
+        expect(described_class.async?).to be true
+      end
+    end
+
+    context 'when the async config has been set to false' do
+      before do
+        described_class.configure { |config| config.async = false }
+      end
+
+      it 'returns false' do
+        expect(described_class.async?).to be false
+      end
+    end
+
+    context 'when the async config has not been set' do
+      before do
+        described_class.configure { |config| config.async = nil }
+      end
+
+      it 'defaults to true' do
+        expect(described_class.async?).to be true
+      end
+    end
+  end
+
   describe '.extract_model_attributes' do
     with_model :Candidate do
       table do |t|


### PR DESCRIPTION
Fixes https://github.com/DFE-Digital/dfe-analytics/issues/203

`DfE::Analytics` initialisation code ignored the `config.async = false` option when provided.

This was caused by the conditional assignment operator `||=`, as `foo ||= true` does set `foo = true` if it was either `nil` or `false`.

Changed it to default to `true` only if no explicit value was set.


**Note regarding failing tests:**
They pass locally, and originally they passed on CI, too. 
Any idea why they could be falling only on CI?

Passing locally:
![image](https://github.com/user-attachments/assets/127250d6-496c-40ef-915f-fb596068f842)
Previous run where they passed on CI:
![image](https://github.com/user-attachments/assets/8ce270a7-9c9f-4856-a8f9-10d9b479ae48)
