### PR TITLE
Change attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ Please note that page caching is project specific and each project must carefull
 
 ## Data health import issues
 
-1. Avoid the use of default scopes, used named scopes if possible. Otherwise the import task will not  catch unscoped entities
+1. Avoid the use of default scopes, used named scopes if possible. Otherwise the import task will not catch unscoped entities
 2. If delete events do not occur at model-level, the after_commit callbacks we use will not be activated.
 E.g. manual deletes in rails console, or relying on a ON DELETE CASCADE in database schema.
 ```

--- a/lib/dfe/analytics/entities.rb
+++ b/lib/dfe/analytics/entities.rb
@@ -23,7 +23,7 @@ module DfE
           # attributes or saved changes in transactions, so we use the
           # TransactionChanges module
 
-          updated_attributes = DfE::Analytics.extract_model_attributes(self, changed_attributes)
+          updated_attributes = DfE::Analytics.extract_model_attributes(self, all_changed_attributes)
 
           allowed_attributes = DfE::Analytics.extract_model_attributes(self).deep_merge(updated_attributes)
 
@@ -31,7 +31,7 @@ module DfE
         end
       end
 
-      def changed_attributes
+      def all_changed_attributes
         changed_attributes = {}
         transaction_changed_attributes.each_key do |name|
           changed_attributes.merge!(name => send(name))


### PR DESCRIPTION
@jebw helpfully pointed out we do not need to overwrite the `changed_attributes` method in entities.rb, I have renamed this to `all_changed_attributes`