### PR TITLE
config added ignore_default_scope

### DIFF
--- a/lib/dfe/analytics/config.rb
+++ b/lib/dfe/analytics/config.rb
@@ -5,6 +5,7 @@ module DfE
     # Define and load configuration for DfE Analytics
     module Config
       CONFIGURABLES = %i[
+        ignore_default_scope
         log_only
         async
         queue
@@ -44,6 +45,7 @@ module DfE
       end
 
       def self.configure(config)
+        config.ignore_default_scope             ||= false
         config.enable_analytics                 ||= proc { true }
         config.bigquery_table_name              ||= ENV.fetch('BIGQUERY_TABLE_NAME', nil)
         config.bigquery_project_id              ||= ENV.fetch('BIGQUERY_PROJECT_ID', nil)

--- a/lib/dfe/analytics/load_entities.rb
+++ b/lib/dfe/analytics/load_entities.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-
+=begin
 module DfE
   module Analytics
     class LoadEntities
@@ -42,6 +42,65 @@ module DfE
           end
           Rails.logger.info "Enqueued #{batch_count} batches of #{BQ_BATCH_ROWS} #{entity_name} records for importing to BigQuery"
         end
+      end
+    end
+  end
+end
+=end
+# frozen_string_literal: true
+
+module DfE
+  module Analytics
+    class LoadEntities
+      # from https://cloud.google.com/bigquery/quotas#streaming_inserts
+      BQ_BATCH_ROWS = 500
+
+      def initialize(entity_name:)
+        @entity_name = entity_name
+      end
+
+      attr_reader :entity_name
+
+      def run(entity_tag:)
+        DfE::Analytics.models_for_entity(entity_name).each do |model|
+          if DfE::Analytics.config.ignore_default_scope && model.respond_to?(:unscoped)
+            model.unscoped { process_model(model, entity_tag) }
+          else
+            process_model(model, entity_tag)
+          end
+        end
+      end
+
+      private
+
+      def process_model(model, entity_tag)
+        unless model.any?
+          Rails.logger.info("No entities to process for #{entity_name}")
+          return
+        end
+
+        primary_key = model.primary_key
+
+        if primary_key.nil?
+          Rails.logger.info("Not processing #{entity_name} as it does not have a primary key")
+          return
+        end
+
+        unless primary_key.to_sym == :id
+          Rails.logger.info("Not processing #{entity_name} as we do not support non-id primary keys")
+          return
+        end
+
+        Rails.logger.info("Processing data for #{entity_name} with row count #{model.count}")
+
+        batch_count = 0
+        model.in_batches(of: BQ_BATCH_ROWS) do |relation|
+          batch_count += 1
+          ids = relation.pluck(:id)
+          DfE::Analytics::LoadEntityBatch.perform_later(model.to_s, ids, entity_tag)
+        end
+
+        Rails.logger.info "Enqueued #{batch_count} batches of #{BQ_BATCH_ROWS} #{entity_name} records for importing to BigQuery"
       end
     end
   end

--- a/spec/dfe/analytics/config_spec.rb
+++ b/spec/dfe/analytics/config_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe DfE::Analytics::Config do
       before { described_class.configure(config) }
 
       it 'sets sane defaults for booleans and procs' do
+        expect(config.ignore_default_scope).to eq(false)
         expect(config.enable_analytics.call).to eq(true)
         expect(config.log_only).to eq(false)
         expect(config.async).to eq(true)

--- a/spec/dummy/config/initializers/dfe_analytics.rb
+++ b/spec/dummy/config/initializers/dfe_analytics.rb
@@ -1,4 +1,8 @@
 DfE::Analytics.configure do |config|
+  # Whether to ignore default scopes when importing to Big Query.
+  #
+  # config.ignore_default_scope = true
+
   # Whether to log events instead of sending them to BigQuery.
   #
   # config.log_only = true


### PR DESCRIPTION
we have added a config option to ignore default scopes when importing model instances to BQ