### PR TITLE
Change sync mode to incremental append for stream connection create

### DIFF
--- a/lib/dfe/analytics/airbyte_stream_config.rb
+++ b/lib/dfe/analytics/airbyte_stream_config.rb
@@ -7,7 +7,7 @@ module DfE
       CURSOR_FIELD = %w[_ab_cdc_lsn].freeze
       AIRBYTE_FIELDS = %w[_ab_cdc_deleted_at _ab_cdc_updated_at].freeze
       DEFAULT_PRIMARY_KEY = 'id'
-      SYNC_MODE = 'incremental'
+      SYNC_MODE = 'incremental_append'
 
       def self.config
         JSON.parse(File.read(DfE::Analytics.config.airbyte_stream_config_path)).deep_symbolize_keys

--- a/spec/dfe/analytics/airbyte_stream_config_spec.rb
+++ b/spec/dfe/analytics/airbyte_stream_config_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe DfE::Analytics::AirbyteStreamConfig do
             streams: [
               {
                 name: 'users',
+                syncMode: 'incremental_append',
+                cursorField: ['_ab_cdc_lsn'],
+                primaryKey: [['id']],
                 selectedFields: [
                   { fieldPath: ['_ab_cdc_lsn'] },
                   { fieldPath: ['_ab_cdc_updated_at'] },
@@ -67,6 +70,8 @@ RSpec.describe DfE::Analytics::AirbyteStreamConfig do
         stream = parsed_config['configurations']['streams'].first
 
         expect(stream['name']).to eq('users')
+        expect(stream['syncMode']).to eq('incremental_append')
+        expect(stream['cursorField']).to eq(['_ab_cdc_lsn'])
         expect(stream['primaryKey']).to eq([['id']])
         expect(stream['selectedFields']).to match_array([
                                                           { 'fieldPath' => ['_ab_cdc_lsn'] },
@@ -105,20 +110,28 @@ RSpec.describe DfE::Analytics::AirbyteStreamConfig do
             streams: [
               {
                 name: 'schools',
+                syncMode: 'incremental_append',
+                cursorField: ['_ab_cdc_lsn'],
+                primaryKey: [['id']],
                 selectedFields: [
                   { fieldPath: ['_ab_cdc_lsn'] },
                   { fieldPath: ['_ab_cdc_updated_at'] },
                   { fieldPath: ['_ab_cdc_deleted_at'] },
+                  { fieldPath: ['id'] },
                   { fieldPath: ['urn'] },
                   { fieldPath: ['name'] }
                 ]
               },
               {
                 name: 'teachers',
+                syncMode: 'incremental_append',
+                cursorField: ['_ab_cdc_lsn'],
+                primaryKey: [['id']],
                 selectedFields: [
                   { fieldPath: ['_ab_cdc_lsn'] },
                   { fieldPath: ['_ab_cdc_updated_at'] },
                   { fieldPath: ['_ab_cdc_deleted_at'] },
+                  { fieldPath: ['id'] },
                   { fieldPath: ['trn'] },
                   { fieldPath: ['dob'] }
                 ]
@@ -132,8 +145,8 @@ RSpec.describe DfE::Analytics::AirbyteStreamConfig do
 
       it 'removes the cursor field and returns attributes' do
         expect(described_class.entity_attributes).to eq(
-          schools: %w[urn name],
-          teachers: %w[trn dob]
+          schools: %w[id urn name],
+          teachers: %w[id trn dob]
         )
       end
     end


### PR DESCRIPTION
Context
Fix sync mode to incremental append for stream connection create

Trello tickets:
https://trello.com/c/hNvJXYfe

Changes proposed in this pull request:
- Change sycn mode to `incremental_append` when generating airbyte stream config for connection creation.
