### PR TITLE
Fix "async" config setup

### DIFF
--- a/lib/dfe/analytics/config.rb
+++ b/lib/dfe/analytics/config.rb
@@ -59,7 +59,6 @@ module DfE
         config.bigquery_timeout                 ||= 120
         config.environment                      ||= ENV.fetch('RAILS_ENV', 'development')
         config.log_only                         ||= false
-        config.async                            ||= true
         config.queue                            ||= :default
         config.user_identifier                  ||= proc { |user| user&.id }
         config.entity_table_checks_enabled      ||= false
@@ -74,6 +73,8 @@ module DfE
         config.airbyte_client_secret            ||= ENV.fetch('AIRBYTE_CLIENT_SECRET', nil)
         config.airbyte_server_url               ||= ENV.fetch('AIRBYTE_SERVER_URL', nil)
         config.airbyte_workspace_id             ||= ENV.fetch('AIRBYTE_WORKSPACE_ID', nil)
+
+        config.async = true if config.async.nil?
 
         config.airbyte_stream_config_path = File.join(Rails.root, config.airbyte_stream_config_path) if config.airbyte_stream_config_path.present?
 

--- a/spec/dfe/analytics_spec.rb
+++ b/spec/dfe/analytics_spec.rb
@@ -202,6 +202,38 @@ RSpec.describe DfE::Analytics do
     end
   end
 
+  describe '.async?' do
+    context 'when the async config has been set to true' do
+      before do
+        described_class.configure { |config| config.async = true }
+      end
+
+      it 'returns true' do
+        expect(described_class.async?).to be true
+      end
+    end
+
+    context 'when the async config has been set to false' do
+      before do
+        described_class.configure { |config| config.async = false }
+      end
+
+      it 'returns false' do
+        expect(described_class.async?).to be false
+      end
+    end
+
+    context 'when the async config has not been set' do
+      before do
+        described_class.configure { |config| config.async = nil }
+      end
+
+      it 'defaults to true' do
+        expect(described_class.async?).to be true
+      end
+    end
+  end
+
   describe '.extract_model_attributes' do
     with_model :Candidate do
       table do |t|


### PR DESCRIPTION
DfE::Analytics initialisation code was ignoring the "config.async = false" option when provided, and setting it to "config.async = true" anyways.

This was caused by the conditional assignment operator "||=".

"foo ||= true" does set 'foo' as 'true' if it was either 'nil' or 'false'.

Based on clone branch from @scruti :

Fixes https://github.com/DFE-Digital/dfe-analytics/issues/203

`DfE::Analytics` initialisation code ignored the `config.async = false` option when provided.

This was caused by the conditional assignment operator `||=`, as `foo ||= true` does set `foo = true` if it was either `nil` or `false`.

Changed it to default to `true` only if no explicit value was set.


**Note regarding failing tests:**
They pass locally, and originally they passed on CI, too. 
Any idea why they could be falling only on CI?

Passing locally:
![image](https://github.com/user-attachments/assets/127250d6-496c-40ef-915f-fb596068f842)
Previous run where they passed on CI:
![image](https://github.com/user-attachments/assets/8ce270a7-9c9f-4856-a8f9-10d9b479ae48)