### PR TITLE
Fix json version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     dfe-analytics (1.15.17)
       google-cloud-bigquery (~> 1.38)
       httparty (~> 0.24)
+      json (< 3)
       multi_xml (~> 0.6.0)
       request_store_rails (~> 2)
 

--- a/dfe-analytics.gemspec
+++ b/dfe-analytics.gemspec
@@ -24,7 +24,11 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency 'google-cloud-bigquery', '~> 1.38'
+  # json 3.0 removed the :quirks_mode option and raises on it; httparty's
+  # response parser still passes it (httparty/parser.rb). Remove this pin once
+  # httparty stops passing :quirks_mode to JSON.parse.
   spec.add_dependency 'httparty', '~> 0.24'
+  spec.add_dependency 'json', '< 3'
   spec.add_dependency 'multi_xml', '~> 0.6.0'
   spec.add_dependency 'request_store_rails', '~> 2'
 

--- a/lib/dfe/analytics/services/entity_table_checks.rb
+++ b/lib/dfe/analytics/services/entity_table_checks.rb
@@ -59,7 +59,7 @@ module DfE
 
         def order_column_exposed_for_entity?(entity_name, columns)
           return false if columns.nil?
-          return true if columns.any? { |column| %w[created_at id].include?(column) }
+          return true if columns.intersect?(%w[created_at id])
 
           Rails.logger.info("DfE::Analytics Processing entity: Order columns missing in analytics.yml for #{entity_name} - Skipping checks")
 

--- a/spec/dfe/analytics/load_entities_spec.rb
+++ b/spec/dfe/analytics/load_entities_spec.rb
@@ -132,11 +132,11 @@ RSpec.describe DfE::Analytics::LoadEntities do
       },
       {
         desc: 'processes unscoped records when global flag is true (overrides per-model settings)',
-        global: true,  listed: false, expected: 2
+        global: true, listed: false, expected: 2
       },
       {
         desc: 'ingests unscoped records when the model is listed and global flag is false',
-        global: false, listed: true,  expected: 2
+        global: false, listed: true, expected: 2
       },
       {
         desc: 'global flag true takes precedence even if the model is listed',


### PR DESCRIPTION
json 3.0 removed the :quirks_mode option and raises on it; httparty's response parser still passes it (httparty/parser.rb). 